### PR TITLE
[ Feat ] profile image type 추가 및 field props 통합

### DIFF
--- a/src/common/component/Textarea/index.tsx
+++ b/src/common/component/Textarea/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import clsx from "clsx";
 import {
   type ForwardedRef,
   type TextareaHTMLAttributes,
@@ -14,13 +15,13 @@ export interface TextareaProps
 
 const Textarea = forwardRef(
   (
-    { isError = false, ...props }: TextareaProps,
+    { isError = false, className, ...props }: TextareaProps,
     ref: ForwardedRef<HTMLTextAreaElement>,
   ) => {
     return (
       <textarea
         ref={ref}
-        className={textareaStyle({ isError })}
+        className={clsx(className, textareaStyle({ isError }))}
         aria-invalid={isError}
         aria-multiline="true"
         {...props}

--- a/src/shared/component/EditAvatar/index.tsx
+++ b/src/shared/component/EditAvatar/index.tsx
@@ -7,32 +7,30 @@ import { iconStyle, inputStyle } from "@/shared/component/EditAvatar/index.css";
 import type { ImageProps } from "next/image";
 import { type ChangeEvent, useState } from "react";
 
-interface EditAvatarProps extends Omit<ImageProps, "src" | "alt"> {
+interface EditAvatarProps extends Omit<ImageProps, "src" | "alt" | "onChange"> {
   src?: string;
   alt?: string;
-  onImageChange: (image: string) => void;
+  onChange?: (img: string | ArrayBuffer | null) => void;
 }
 
 const EditAvatar = ({
   src = "",
   alt = "프로필 사진 수정",
-  onImageChange,
+  onChange,
   ...props
 }: EditAvatarProps) => {
   const [pickedImage, setPickedImage] = useState<string | null>(src || null);
-
   const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file) {
-      setPickedImage(src);
-      return;
-    }
+    if (!file) return;
+    if (pickedImage && !file.type.includes("image")) return;
 
     const fileReader = new FileReader();
     fileReader.onload = () => {
       setPickedImage(fileReader.result as string);
-      onImageChange(fileReader.result as string);
+      onChange?.(fileReader.result);
     };
+
     fileReader.readAsDataURL(file);
   };
 

--- a/src/shared/component/Form/Form.stories.tsx
+++ b/src/shared/component/Form/Form.stories.tsx
@@ -70,7 +70,7 @@ export const LoginForm: Story = {
                 showDescription
                 descriptionPosition="top"
                 descriptionProps={{ isError, message, id: "form-description" }} // description 공유
-                inputProps={{
+                fieldProps={{
                   className: itemStyle.input,
                   placeholder: "아이디",
                   "aria-describedby": "form-description", // description 공유
@@ -80,7 +80,7 @@ export const LoginForm: Story = {
                 form={form}
                 type="input"
                 name="password"
-                inputProps={{
+                fieldProps={{
                   className: itemStyle.input,
                   placeholder: "비밀번호",
                   "aria-describedby": "form-description", // description 공유
@@ -150,7 +150,7 @@ export const PasswordConfirm: Story = {
                 form={form}
                 type="input"
                 name="password"
-                inputProps={{
+                fieldProps={{
                   className: itemStyle.input,
                   placeholder: "비밀번호",
                   "aria-describedby": "password-description", // description 공유 (confirm password)
@@ -170,7 +170,7 @@ export const PasswordConfirm: Story = {
                   message,
                   id: "password-description", // description 공유 (confirm password)
                 }}
-                inputProps={{
+                fieldProps={{
                   className: itemStyle.input,
                   placeholder: "비밀번호 확인",
                   "aria-describedby": "password-description", // description 공유 (confirm password)
@@ -265,7 +265,7 @@ export const ValidateOnServer: Story = {
                   className: itemStyle.label,
                   children: "닉네임(서버에서 검증)",
                 }}
-                inputProps={{
+                fieldProps={{
                   className: itemStyle.input,
                   placeholder: "닉네임",
                 }}
@@ -285,7 +285,7 @@ export const ValidateOnServer: Story = {
                   className: itemStyle.label,
                   children: "백준 아이디(서버에서 검증)",
                 }}
-                inputProps={{
+                fieldProps={{
                   className: itemStyle.input,
                   placeholder: "백준 아이디",
                 }}
@@ -304,7 +304,7 @@ export const ValidateOnServer: Story = {
                   className: itemStyle.label,
                   children: "소개(서버 x)",
                 }}
-                inputProps={{
+                fieldProps={{
                   className: itemStyle.input,
                   placeholder: "소개",
                 }}
@@ -314,6 +314,58 @@ export const ValidateOnServer: Story = {
               회원가입하기
             </Button>
           </div>
+        </form>
+      </Form>
+    );
+  },
+};
+
+export const Profile: Story = {
+  render: () => {
+    const postSchema = z.object({
+      profileImage: z.string(),
+
+      title: z
+        .string()
+        .min(6)
+        .max(12)
+        .regex(/^[a-zA-Z가-하0-9]+$/),
+    });
+
+    const form = useForm<z.infer<typeof postSchema>>({
+      resolver: zodResolver(postSchema),
+      mode: "onTouched",
+      defaultValues: {
+        title: "",
+        profileImage: "",
+      },
+    });
+    const onSubmit = (values: z.infer<typeof postSchema>) => {
+      console.log({ values });
+    };
+
+    return (
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className={storyFormStyle({ type: "post" })}
+        >
+          <div className={storyContentStyle.profileContents}>
+            <FormController form={form} type="image" name="profileImage" />
+
+            <FormController
+              form={form}
+              type="input"
+              name="title"
+              showDescription
+              fieldProps={{
+                placeholder: "제목",
+              }}
+            />
+          </div>
+          <Button type="submit" size="medium">
+            등록
+          </Button>
         </form>
       </Form>
     );
@@ -350,7 +402,7 @@ export const DateTypeWithErrorMsg: Story = {
     });
 
     const onSubmit = (values: z.infer<typeof postSchema>) => {
-      alert(`${values.startDate.toLocaleDateString()}, ${values.title}`);
+      console.log({ values });
     };
 
     return (
@@ -365,7 +417,7 @@ export const DateTypeWithErrorMsg: Story = {
               type="input"
               name="title"
               showDescription
-              inputProps={{
+              fieldProps={{
                 placeholder: "제목",
               }}
             />
@@ -380,7 +432,7 @@ export const DateTypeWithErrorMsg: Story = {
                 labelProps={{
                   children: "시작 일자",
                 }}
-                dateProps={{
+                fieldProps={{
                   ariaDescribedBy: "date-description", // description 공유 (start date)
                 }}
                 descriptionProps={{
@@ -400,7 +452,7 @@ export const DateTypeWithErrorMsg: Story = {
                 labelProps={{
                   children: "종료 일자",
                 }}
-                dateProps={{
+                fieldProps={{
                   ariaDescribedBy: "date-description", // description 공유 (start date)
                 }}
               />

--- a/src/shared/component/Form/index.css.ts
+++ b/src/shared/component/Form/index.css.ts
@@ -37,6 +37,13 @@ export const storyContentStyle = styleVariants({
 
     width: "34rem",
   },
+  profileContents: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "3rem",
+
+    width: "34rem",
+  },
   editContents: {
     display: "flex",
     flexDirection: "column",

--- a/src/shared/component/Form/index.tsx
+++ b/src/shared/component/Form/index.tsx
@@ -12,6 +12,7 @@ import {
   FormProvider,
   type UseFormReturn,
 } from "react-hook-form";
+import EditAvatar from "../EditAvatar";
 import FormDescription from "./FormDescription";
 import FormLabel from "./FormLabel";
 import { itemDefaultStyle, itemStyle } from "./index.css";
@@ -20,7 +21,6 @@ type FormFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
 > = {
-  type: "input" | "textarea" | "date";
   name: TName;
   labelPosition?: "top" | "bottom";
   descriptionPosition?: "top" | "bottom";
@@ -29,11 +29,13 @@ type FormFieldProps<
   revalidationHandlers?: typeof getRevalidationOnServerHandlers;
   form: UseFormReturn<TFieldValues>;
   labelProps?: ComponentProps<typeof FormLabel>;
-  inputProps?: ComponentProps<typeof Input>;
-  textareaProps?: ComponentProps<typeof Textarea>;
-  dateProps?: ComponentProps<typeof Calendar>;
   descriptionProps?: ComponentProps<typeof FormDescription>;
-};
+} & (
+  | { type: "input"; fieldProps?: ComponentProps<typeof Input> }
+  | { type: "textarea"; fieldProps?: ComponentProps<typeof Textarea> }
+  | { type: "date"; fieldProps?: ComponentProps<typeof Calendar> }
+  | { type: "image"; fieldProps?: ComponentProps<typeof EditAvatar> }
+);
 
 const FormController = <
   TFieldValues extends FieldValues,
@@ -48,9 +50,7 @@ const FormController = <
   revalidationHandlers,
   form,
   labelProps,
-  inputProps,
-  textareaProps,
-  dateProps,
+  fieldProps,
   descriptionProps,
 }: FormFieldProps<TFieldValues, TName>) => {
   return (
@@ -84,18 +84,20 @@ const FormController = <
         );
         let FormField: ReactNode;
         if (type === "input") {
-          FormField = <Input size="large" {...props} {...inputProps} />;
+          FormField = <Input size="large" {...fieldProps} {...props} />;
         } else if (type === "textarea") {
-          FormField = <Textarea {...props} {...textareaProps} />;
-        } else {
+          FormField = <Textarea {...fieldProps} {...props} />;
+        } else if (type === "date") {
           FormField = (
             <Calendar
               id={fieldId}
-              {...dateProps}
+              {...fieldProps}
               onChange={field.onChange}
               onBlur={field.onBlur}
             />
           );
+        } else {
+          FormField = <EditAvatar {...fieldProps} onChange={field.onChange} />;
         }
         return (
           <div className={clsx(itemDefaultStyle)}>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #82 

## ✅ Done Task
  - [x] `FormController`에 image type 추가
  - [x] inputProps, textareaProps, dateProps, imageProps를 fieldProps로 통합 (field 요소에 줄 props입니다)
  - [x] 스토리 업데이트

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- edit avatar 수정
FormController에서 사용할 수 있게 타입을 수정하고 `handleImageChange` 함수의 파일 검사 부분을 다음과 같이 변경했습니다.
  ```typescript
  if (!file) return; // 타입스크립트 타입 narrowing을 위해 굳이 사용
  if (pickedImage && !file.type.includes("image")) return;
  ```
  파일 탐색기에서 파일 형식을 `모든 파일`로 하여 다른 형식의 파일을 넣을 수 있기 때문에 파일 타입 검사를 추가하고, 사용자가 선택한 프로필 이미지가 있을 때 다시 창을 열어 취소 버튼을 누르면 기본 이미지로 돌아가는 버그가 다시 생겨 이를 수정했습니다.
- FormController 타입 수정
```typescript
type FormFieldProps<
  TFieldValues extends FieldValues,
  TName extends FieldPath<TFieldValues>,
> = {
  name: TName;
  labelPosition?: "top" | "bottom";
  descriptionPosition?: "top" | "bottom";
  showLabel?: boolean;
  showDescription?: boolean;
  revalidationHandlers?: typeof getRevalidationOnServerHandlers;
  form: UseFormReturn<TFieldValues>;
  labelProps?: ComponentProps<typeof FormLabel>;
  descriptionProps?: ComponentProps<typeof FormDescription>;
} & (
  | { type: "input"; fieldProps?: ComponentProps<typeof Input> }
  | { type: "textarea"; fieldProps?: ComponentProps<typeof Textarea> }
  | { type: "date"; fieldProps?: ComponentProps<typeof Calendar> }
  | { type: "image"; fieldProps?: ComponentProps<typeof EditAvatar> }
);
```
  조건부 타입을 적용하여 사용하려는 type에 따라 해당하는 `ComponentProps`가 선택됩니다.
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
- `<FormController type="image">` 로 사용할 수 있습니다. values에는 이미지의 blob string값이 나옵니다.
![image](https://github.com/user-attachments/assets/8a84c0d5-7d3a-47bd-a7b4-c70f315fc7d8)
