### PR TITLE
[ Feat ] Problem List Item 컴포넌트 퍼블리싱

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-datepicker": "^7.3.0",
     "react-dom": "^18",
     "react-hook-form": "^7.53.0",
+    "ts-pattern": "^5.4.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-hook-form:
         specifier: ^7.53.0
         version: 7.53.0(react@18.3.1)
+      ts-pattern:
+        specifier: ^5.4.0
+        version: 5.4.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -4331,6 +4334,9 @@ packages:
   ts-morph@21.0.1:
     resolution: {integrity: sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==}
 
+  ts-pattern@5.4.0:
+    resolution: {integrity: sha512-hgfOMfjlrARCnYtGD/xEAkFHDXuSyuqjzFSltyQCbN689uNvoQL20TVN2XFcLMjfNuwSsQGU+xtH6MrjIwhwUg==}
+
   ts-pnp@1.2.0:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
@@ -5686,7 +5692,7 @@ snapshots:
   '@hookform/resolvers@3.9.0(react-hook-form@7.53.0(react@18.3.1))':
     dependencies:
       react-hook-form: 7.53.0(react@18.3.1)
-      
+
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.0.4
@@ -9233,6 +9239,8 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.22.0
       code-block-writer: 12.0.0
+
+  ts-pattern@5.4.0: {}
 
   ts-pnp@1.2.0(typescript@5.5.4):
     optionalDependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import Header from "@/shared/component/Header";
 import Providers from "@/shared/component/Provider";
 import "@/styles/globalStyles.css";
 import type { Metadata } from "next";
-import "@/styles/globalStyles.css";
 
 export const metadata: Metadata = {
   title: "AlgoHub",

--- a/src/common/component/CheckBox/CheckBox.stories.tsx
+++ b/src/common/component/CheckBox/CheckBox.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta } from "@storybook/react";
+import CheckBox from ".";
+
+const meta: Meta<typeof CheckBox> = {
+  title: "Common/CheckBox",
+  component: CheckBox,
+  tags: ["autodocs"],
+} satisfies Meta<typeof CheckBox>;
+export default meta;
+
+export const Default = {
+  args: {
+    checked: false,
+  },
+};
+
+export const Checked = {
+  args: {
+    checked: true,
+  },
+};

--- a/src/common/component/CheckBox/CheckBox.stories.tsx
+++ b/src/common/component/CheckBox/CheckBox.stories.tsx
@@ -1,6 +1,6 @@
+import CheckBox from "@/common/component/CheckBox";
 import type { Meta } from "@storybook/react";
-import CheckBox from ".";
-
+import { useState } from "react";
 const meta: Meta<typeof CheckBox> = {
   title: "Common/CheckBox",
   component: CheckBox,
@@ -17,5 +17,18 @@ export const Default = {
 export const Checked = {
   args: {
     checked: true,
+  },
+};
+
+export const Playground = {
+  render: () => {
+    const [checked, setChecked] = useState(false);
+
+    return (
+      <CheckBox
+        checked={checked}
+        onChange={() => setChecked((prev) => !prev)}
+      />
+    );
   },
 };

--- a/src/common/component/CheckBox/index.css.ts
+++ b/src/common/component/CheckBox/index.css.ts
@@ -3,13 +3,15 @@ import { style } from "@vanilla-extract/css";
 
 export const boxStyle = style({
   appearance: "none",
+  WebkitAppearance: "none",
+  MozAppearance: "none",
 
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
 
-  width: "14px",
-  height: "14px",
+  width: "1.4rem",
+  height: "1.4rem",
 
   border: "none",
   borderRadius: "1px",

--- a/src/common/component/CheckBox/index.css.ts
+++ b/src/common/component/CheckBox/index.css.ts
@@ -16,6 +16,8 @@ export const boxStyle = style({
 
   backgroundColor: theme.color.mg3,
 
+  cursor: "pointer",
+
   ":checked": {
     backgroundColor: theme.color.purple,
   },

--- a/src/common/component/CheckBox/index.css.ts
+++ b/src/common/component/CheckBox/index.css.ts
@@ -1,0 +1,30 @@
+import { theme } from "@/styles/themes.css";
+import { style } from "@vanilla-extract/css";
+
+export const boxStyle = style({
+  appearance: "none",
+
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+
+  width: "14px",
+  height: "14px",
+
+  border: "none",
+  borderRadius: "1px",
+
+  backgroundColor: theme.color.mg3,
+
+  ":checked": {
+    backgroundColor: theme.color.purple,
+  },
+
+  "::before": {
+    content: "✓",
+
+    fontWeight: 700,
+
+    color: theme.color.black,
+  },
+});

--- a/src/common/component/CheckBox/index.tsx
+++ b/src/common/component/CheckBox/index.tsx
@@ -1,13 +1,16 @@
 import { boxStyle } from "@/common/component/CheckBox/index.css";
+import type { HTMLAttributes } from "react";
 
-interface CheckBoxProps {
+interface CheckBoxProps
+  extends Omit<HTMLAttributes<HTMLInputElement>, "onChange"> {
   checked: boolean;
   onChange?: (checked: boolean) => void;
 }
 
-const CheckBox = ({ checked, onChange }: CheckBoxProps) => {
+const CheckBox = ({ checked, onChange, ...props }: CheckBoxProps) => {
   return (
     <input
+      {...props}
       className={boxStyle}
       type="checkbox"
       checked={checked}

--- a/src/common/component/CheckBox/index.tsx
+++ b/src/common/component/CheckBox/index.tsx
@@ -1,0 +1,19 @@
+import { boxStyle } from "@/common/component/CheckBox/index.css";
+
+interface CheckBoxProps {
+  checked: boolean;
+  onChange?: (checked: boolean) => void;
+}
+
+const CheckBox = ({ checked, onChange }: CheckBoxProps) => {
+  return (
+    <input
+      className={boxStyle}
+      type="checkbox"
+      checked={checked}
+      onChange={() => onChange?.(!checked)}
+    />
+  );
+};
+
+export default CheckBox;

--- a/src/shared/component/ProblemList/Item.tsx
+++ b/src/shared/component/ProblemList/Item.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import CheckBox from "@/common/component/CheckBox";
 import { getTierImage } from "@/shared/component/ProblemList/img";
 import {

--- a/src/shared/component/ProblemList/Item.tsx
+++ b/src/shared/component/ProblemList/Item.tsx
@@ -6,6 +6,7 @@ import {
   wrongCheckBoxStyle,
 } from "@/shared/component/ProblemList/index.css";
 import type { Problem } from "@/shared/type";
+import { format } from "date-fns";
 import Link from "next/link";
 import { match } from "ts-pattern";
 
@@ -30,7 +31,7 @@ const ProblemListItem = ({
       <Link href={`/problem/${id}`}>
         <span className={textStyle}>{title}</span>
       </Link>
-      <span className={textStyle}>{date}</span>
+      <span className={textStyle}>{format(date, "yyyy.MM.dd")}</span>
       <span className={textStyle}>{`${solved}/${total}`}</span>
       <span className={textStyle}>{`${accuracy}%`}</span>
       {match(status)

--- a/src/shared/component/ProblemList/Item.tsx
+++ b/src/shared/component/ProblemList/Item.tsx
@@ -1,0 +1,51 @@
+import CheckBox from "@/common/component/CheckBox";
+import { getTierImage } from "@/shared/component/ProblemList/img";
+import {
+  itemStyle,
+  textStyle,
+  wrongCheckBoxStyle,
+} from "@/shared/component/ProblemList/index.css";
+import type { Problem } from "@/shared/type";
+import Link from "next/link";
+import { match } from "ts-pattern";
+
+type ProblemListItemProps = Problem;
+
+const ProblemListItem = ({
+  id,
+  title,
+  date,
+  tier,
+  status,
+  solved,
+  total,
+}: ProblemListItemProps) => {
+  const Icon = getTierImage(tier);
+
+  const accuracy = ((solved / total) * 100).toFixed(0);
+
+  return (
+    <li className={itemStyle}>
+      <Icon width={25} height={32} />
+      <Link href={`/problem/${id}`}>
+        <span className={textStyle}>{title}</span>
+      </Link>
+      <span className={textStyle}>{date}</span>
+      <span className={textStyle}>{`${solved}/${total}`}</span>
+      <span className={textStyle}>{`${accuracy}%`}</span>
+      {match(status)
+        .with("wrong", () => (
+          <input type="checkbox" disabled className={wrongCheckBoxStyle} />
+        ))
+        .with("unsolved", () => (
+          <CheckBox checked={false} style={{ cursor: "default" }} />
+        ))
+        .with("solved", () => (
+          <CheckBox checked={true} style={{ cursor: "default" }} />
+        ))
+        .exhaustive()}
+    </li>
+  );
+};
+
+export default ProblemListItem;

--- a/src/shared/component/ProblemList/Item.tsx
+++ b/src/shared/component/ProblemList/Item.tsx
@@ -5,6 +5,7 @@ import { getTierImage } from "@/shared/component/ProblemList/img";
 import {
   itemStyle,
   textStyle,
+  titleStyle,
   wrongCheckBoxStyle,
 } from "@/shared/component/ProblemList/index.css";
 import type { Problem } from "@/shared/type";
@@ -30,7 +31,7 @@ const ProblemListItem = ({
   return (
     <li className={itemStyle}>
       <Icon width={25} height={32} />
-      <Link href={`/problem/${id}`}>
+      <Link className={`${titleStyle} ${textStyle}`} href={`/problem/${id}`}>
         <span className={textStyle}>{title}</span>
       </Link>
       <span className={textStyle}>{format(date, "yyyy.MM.dd")}</span>

--- a/src/shared/component/ProblemList/Item.tsx
+++ b/src/shared/component/ProblemList/Item.tsx
@@ -11,9 +11,14 @@ import {
 import type { Problem } from "@/shared/type";
 import { format } from "date-fns";
 import Link from "next/link";
-import { match } from "ts-pattern";
 
 type ProblemListItemProps = Problem;
+
+const JSX_BY_STATUS = {
+  wrong: <input type="checkbox" disabled className={wrongCheckBoxStyle} />,
+  unsolved: <CheckBox checked={false} style={{ cursor: "default" }} />,
+  solved: <CheckBox checked={true} style={{ cursor: "default" }} />,
+};
 
 const ProblemListItem = ({
   id,
@@ -29,25 +34,17 @@ const ProblemListItem = ({
   const accuracy = ((solved / total) * 100).toFixed(0);
 
   return (
-    <li className={itemStyle}>
+    <li aria-label={`문제: ${title}`} className={itemStyle}>
       <Icon width={25} height={32} />
       <Link className={`${titleStyle} ${textStyle}`} href={`/problem/${id}`}>
         <span className={textStyle}>{title}</span>
       </Link>
-      <span className={textStyle}>{format(date, "yyyy.MM.dd")}</span>
+      <time dateTime={date} className={textStyle}>
+        {format(date, "yyyy.MM.dd")}
+      </time>
       <span className={textStyle}>{`${solved}/${total}`}</span>
       <span className={textStyle}>{`${accuracy}%`}</span>
-      {match(status)
-        .with("wrong", () => (
-          <input type="checkbox" disabled className={wrongCheckBoxStyle} />
-        ))
-        .with("unsolved", () => (
-          <CheckBox checked={false} style={{ cursor: "default" }} />
-        ))
-        .with("solved", () => (
-          <CheckBox checked={true} style={{ cursor: "default" }} />
-        ))
-        .exhaustive()}
+      {JSX_BY_STATUS[status]}
     </li>
   );
 };

--- a/src/shared/component/ProblemList/ProblemList.stories.tsx
+++ b/src/shared/component/ProblemList/ProblemList.stories.tsx
@@ -1,0 +1,62 @@
+import type { TierDetail } from "@/shared/type";
+import type { Meta } from "@storybook/react";
+import ProblemList from ".";
+
+const meta: Meta<typeof ProblemList> = {
+  title: "Shared/ProblemList",
+  component: ProblemList,
+  tags: ["autodocs"],
+  args: {},
+} satisfies Meta<typeof ProblemList>;
+export default meta;
+
+export const Default = {
+  render: () => {
+    const data = [
+      {
+        id: 1,
+        title: "트리에서의 동적 계획법",
+        date: "2024-01-01",
+        tier: "silver 1",
+        status: "solved",
+        solved: 50,
+        total: 200,
+      },
+      {
+        id: 2,
+        title: "백트래킹",
+        date: "2024-03-03",
+        tier: "bronze 5",
+        status: "unsolved",
+        solved: 50,
+        total: 200,
+      },
+      {
+        id: 3,
+        title: "깊이/너비 우선 탐색",
+        date: "2024-01-01",
+        tier: "diamond 3",
+        status: "wrong",
+        solved: 50,
+        total: 200,
+      },
+    ];
+
+    return (
+      <ProblemList>
+        {data.map(({ id, title, date, tier, status, solved, total }) => (
+          <ProblemList.Item
+            key={id}
+            id={id}
+            title={title}
+            date={date}
+            tier={tier as TierDetail}
+            status={status as "solved" | "wrong" | "unsolved"}
+            solved={solved}
+            total={total}
+          />
+        ))}
+      </ProblemList>
+    );
+  },
+};

--- a/src/shared/component/ProblemList/img.ts
+++ b/src/shared/component/ProblemList/img.ts
@@ -1,0 +1,102 @@
+import type { TierDetail } from "@/shared/type";
+
+import {
+  IcnBronze1,
+  IcnBronze2,
+  IcnBronze3,
+  IcnBronze4,
+  IcnBronze5,
+  IcnDiamond1,
+  IcnDiamond2,
+  IcnDiamond3,
+  IcnDiamond4,
+  IcnDiamond5,
+  IcnGold1,
+  IcnGold2,
+  IcnGold3,
+  IcnGold4,
+  IcnGold5,
+  IcnMaster,
+  IcnPlatinum1,
+  IcnPlatinum2,
+  IcnPlatinum3,
+  IcnPlatinum4,
+  IcnPlatinum5,
+  IcnRuby1,
+  IcnRuby2,
+  IcnRuby3,
+  IcnRuby4,
+  IcnRuby5,
+  IcnSilver1,
+  IcnSilver2,
+  IcnSilver3,
+  IcnSilver4,
+  IcnSilver5,
+} from "@/asset/svg";
+
+export const getTierImage = (tier: TierDetail) => {
+  switch (tier) {
+    case "bronze 1":
+      return IcnBronze1;
+    case "bronze 2":
+      return IcnBronze2;
+    case "bronze 3":
+      return IcnBronze3;
+    case "bronze 4":
+      return IcnBronze4;
+    case "bronze 5":
+      return IcnBronze5;
+    case "silver 1":
+      return IcnSilver1;
+    case "silver 2":
+      return IcnSilver2;
+    case "silver 3":
+      return IcnSilver3;
+    case "silver 4":
+      return IcnSilver4;
+    case "silver 5":
+      return IcnSilver5;
+    case "gold 1":
+      return IcnGold1;
+    case "gold 2":
+      return IcnGold2;
+    case "gold 3":
+      return IcnGold3;
+    case "gold 4":
+      return IcnGold4;
+    case "gold 5":
+      return IcnGold5;
+    case "platinum 1":
+      return IcnPlatinum1;
+    case "platinum 2":
+      return IcnPlatinum2;
+    case "platinum 3":
+      return IcnPlatinum3;
+    case "platinum 4":
+      return IcnPlatinum4;
+    case "platinum 5":
+      return IcnPlatinum5;
+    case "diamond 1":
+      return IcnDiamond1;
+    case "diamond 2":
+      return IcnDiamond2;
+    case "diamond 3":
+      return IcnDiamond3;
+    case "diamond 4":
+      return IcnDiamond4;
+    case "diamond 5":
+      return IcnDiamond5;
+    case "ruby 1":
+      return IcnRuby1;
+    case "ruby 2":
+      return IcnRuby2;
+    case "ruby 3":
+      return IcnRuby3;
+    case "ruby 4":
+      return IcnRuby4;
+    case "ruby 5":
+      return IcnRuby5;
+    case "master":
+      return IcnMaster;
+  }
+};

--- a/src/shared/component/ProblemList/index.css.ts
+++ b/src/shared/component/ProblemList/index.css.ts
@@ -1,0 +1,43 @@
+import { theme } from "@/styles/themes.css";
+import { style } from "@vanilla-extract/css";
+
+export const itemStyle = style({
+  display: "grid",
+  gridTemplateColumns: "0.6fr 2.7fr 2fr 2fr 2fr 2fr",
+  alignItems: "center",
+  gap: "2.4rem",
+
+  width: "100%",
+
+  padding: "0.8rem 1.6rem",
+});
+
+export const textStyle = style({
+  ...theme.font.Caption3_M_12,
+  color: theme.color.white,
+
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+});
+
+export const wrongCheckBoxStyle = style({
+  appearance: "none",
+
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+
+  width: "14px",
+  height: "14px",
+
+  border: "none",
+  borderRadius: "1px",
+
+  backgroundColor: theme.color.red,
+
+  "::before": {
+    content: "Ｘ",
+
+    color: theme.color.white,
+  },
+});

--- a/src/shared/component/ProblemList/index.css.ts
+++ b/src/shared/component/ProblemList/index.css.ts
@@ -20,6 +20,10 @@ export const textStyle = style({
   textOverflow: "ellipsis",
 });
 
+export const titleStyle = style({
+  whiteSpace: "nowrap",
+});
+
 export const wrongCheckBoxStyle = style({
   appearance: "none",
 

--- a/src/shared/component/ProblemList/index.tsx
+++ b/src/shared/component/ProblemList/index.tsx
@@ -1,0 +1,12 @@
+import ProblemListItem from "@/shared/component/ProblemList/Item";
+import type { PropsWithChildren } from "react";
+
+type ProblemListProps = PropsWithChildren;
+
+const ProblemList = ({ children, ...props }: ProblemListProps) => {
+  return <ul {...props}>{children}</ul>;
+};
+
+ProblemList.Item = ProblemListItem;
+
+export default ProblemList;

--- a/src/shared/type/index.ts
+++ b/src/shared/type/index.ts
@@ -1,1 +1,21 @@
 export type Timeout = ReturnType<typeof setTimeout>;
+
+export interface Problem {
+  id: string | number;
+  tier: TierDetail;
+  title: string;
+  date: string;
+  solved: number;
+  total: number;
+  status: "solved" | "unsolved" | "wrong";
+}
+
+export type tier =
+  | "bronze"
+  | "silver"
+  | "gold"
+  | "platinum"
+  | "diamond"
+  | "ruby";
+
+export type TierDetail = `${tier} ${1 | 2 | 3 | 4 | 5}` | "master";


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #86 

## ✅ Done Task
  - [x] List 컨테이너 + Item 컴포넌트 구현
  - [x] CheckBox 컴포넌트 구현

## ☀️ New-insight
타입스크립트 환경에서 분기처리를 선언적으로 바꾸어주는 `ts-pattern` 라이브러리를 사용하였습니다. 해당 아이템 컴포넌트를 만드는 과정에서, 티어별 혹은 문제의 상태 별 분기처리가 필수적으로 들어가기 때문에, 삼항연산자나 `&&` 등의 연산자보다는 더욱 선언적으로 깔끔하게 조건부 렌더링을 작성하기 위해서 적용해보았습니다.

## 💎 PR Point

### List + Item 컴포넌트 퍼블리싱

먼저 List와 `List.Item`으로 접근 가능하게 합성 컴포넌트로 구현하였습니다. `List` 컴포넌트에게 `children`이 아닌 다른 기타 배열의 `props`로 넘겨주고, `List` 컴포넌트에서 아이템 컴포넌트까지 모두 렌더링할 수는 있지만, 사용하는 쪽에서 `List.Item`와 함께 사용하게 하면서 `Item`에 직접 넘기는 `prop`들을 관리할 수 있도록 구현하였습니다.

```ts
<li className={itemStyle}>
      <Icon width={25} height={32} />
      <Link href={`/problem/${id}`}>
        <span className={textStyle}>{title}</span>
      </Link>
      <span className={textStyle}>{format(date, "yyyy.MM.dd")}</span>
      <span className={textStyle}>{`${solved}/${total}`}</span>
      <span className={textStyle}>{`${accuracy}%`}</span>
      {match(status)
        .with("wrong", () => (
          <input type="checkbox" disabled className={wrongCheckBoxStyle} />
        ))
        .with("unsolved", () => (
          <CheckBox checked={false} style={{ cursor: "default" }} />
        ))
        .with("solved", () => (
          <CheckBox checked={true} style={{ cursor: "default" }} />
        ))
        .exhaustive()}
    </li>
```

보시다 시피 아이템 컴포넌트에는 `tier`, `title`, `date` ,`solved`, `accuracy`, `status` 6개의 필드가 있는데요, 이를 정렬시키는 과정에서 `grid`를 이용했고, 피그마 디자인에서 대략적인 수치를 반영하여 비율을 다르게 주었습니다.

### CheckBox 공통 컴포넌트

해당 List Item 가장 오른쪽에 있는 `Status` 필드를 퍼블리싱하기 위해 `CheckBox`를 따로 공통으로 분리하기로 결정하였습니다. 그리고 해당 아이템 컴포넌트에서는 체크박스의 `checked` 상태가 결정되어 있으므로 그냥 `boolean` 값을 넘겨 체크 상태가 고정된 상태로 렌더링되도록 하였습니다. 그리고 `X` 표시되어 있는 빨간 체크박스는 사실 `CheckBox`라는 컴포넌트가 일반적으로 수행해야할 책임은 아니라고 생각하였고 특별한 케이스라고 판단하여  아이템 컴포넌트 쪽에서 작성해주었습니다.


## 📸 Screenshot


https://github.com/user-attachments/assets/4142a021-b552-4a6d-99a3-7ba2236139a0

뷰포트가 줄어들 때 `gap`을 준 만큼 간격을 유지하며, 텍스트가 줄어들어야 할 시 `ellipsis`가 적용되도록 구현하였습니다.
