### PR TITLE
[ Fix ] 시작일, 종료일 수정 시 바로 반영, edit avatar에 업로드한 이미지 표시

### DIFF
--- a/src/api/group/schema.ts
+++ b/src/api/group/schema.ts
@@ -11,17 +11,7 @@ export const groupSchema = z
     endDate: z.date(),
     desc: z.string(),
   })
-  .superRefine((data, ctx) => {
-    if (data.endDate < data.startDate) {
-      ctx.addIssue({
-        path: ["endDate"],
-        message: "종료 일자는 시작 일자보다 나중이어야 합니다.",
-        code: "custom",
-      });
-      ctx.addIssue({
-        path: ["startDate"],
-        message: "종료 일자는 시작 일자보다 나중이어야 합니다.",
-        code: "custom",
-      });
-    }
+  .refine((data) => data.endDate >= data.startDate, {
+    message: "종료 일자는 시작 일자보다 나중이어야 합니다.",
+    path: ["endDate"],
   });

--- a/src/api/group/schema.ts
+++ b/src/api/group/schema.ts
@@ -11,7 +11,17 @@ export const groupSchema = z
     endDate: z.date(),
     desc: z.string(),
   })
-  .refine((data) => data.endDate >= data.startDate, {
-    message: "종료 일자는 시작 일자보다 나중이어야 합니다.",
-    path: ["endDate"],
+  .superRefine((data, ctx) => {
+    if (data.endDate < data.startDate) {
+      ctx.addIssue({
+        path: ["endDate"],
+        message: "종료 일자는 시작 일자보다 나중이어야 합니다.",
+        code: "custom",
+      });
+      ctx.addIssue({
+        path: ["startDate"],
+        message: "종료 일자는 시작 일자보다 나중이어야 합니다.",
+        code: "custom",
+      });
+    }
   });

--- a/src/shared/component/EditAvatar/index.tsx
+++ b/src/shared/component/EditAvatar/index.tsx
@@ -45,7 +45,7 @@ const EditAvatar = ({
 
   return (
     <Avatar
-      src={pickedImage || (variant === "default" ? defaultImg : grayDefaultImg)}
+      src={pickedImage ?? (variant === "default" ? defaultImg : grayDefaultImg)}
       alt={alt}
       size="large"
       {...props}

--- a/src/shared/component/EditAvatar/index.tsx
+++ b/src/shared/component/EditAvatar/index.tsx
@@ -45,7 +45,7 @@ const EditAvatar = ({
 
   return (
     <Avatar
-      src={pickedImage || variant === "default" ? defaultImg : grayDefaultImg}
+      src={pickedImage || (variant === "default" ? defaultImg : grayDefaultImg)}
       alt={alt}
       size="large"
       {...props}

--- a/src/shared/component/Form/index.tsx
+++ b/src/shared/component/Form/index.tsx
@@ -94,6 +94,10 @@ const FormController = <
               {...fieldProps}
               onChange={field.onChange}
               onBlur={field.onBlur}
+              {...revalidationHandlers?.(
+                form as UseFormReturn,
+                field as ControllerRenderProps,
+              )}
             />
           );
         } else {

--- a/src/shared/component/GroupInfoForm/DateFormController.tsx
+++ b/src/shared/component/GroupInfoForm/DateFormController.tsx
@@ -4,6 +4,7 @@ import {
   dateInputStyle,
   dateLabelStyle,
 } from "@/shared/component/GroupInfoForm/index.css";
+import { getMultipleRevalidationHandlers } from "@/shared/util/form";
 
 interface DateFormControllerProps extends GroupFormProps {
   dateType: "startDate" | "endDate";
@@ -19,6 +20,9 @@ const DateFormController = ({
       name={dateType}
       type="date"
       showLabel
+      revalidationHandlers={getMultipleRevalidationHandlers(
+        dateType === "startDate" ? "endDate" : "startDate",
+      )}
       labelProps={{
         children: dateType === "startDate" ? "시작 일자" : "종료 일자",
         className: dateLabelStyle({ variant }),

--- a/src/shared/component/GroupInfoForm/index.tsx
+++ b/src/shared/component/GroupInfoForm/index.tsx
@@ -27,8 +27,7 @@ const GroupInfoForm = ({
   const handleSubmit = (_values: z.infer<typeof groupSchema>) => {
     // console.log({ values });
   };
-  const { startDate, endDate } = form.formState.errors;
-  const errors = startDate || endDate;
+  const error = form.formState.errors.endDate;
   return (
     <Form {...form}>
       <form
@@ -51,8 +50,8 @@ const GroupInfoForm = ({
               dateType="endDate"
             />
           </div>
-          {!!errors && (
-            <SupportingText isError hasErrorIcon message={errors.message} />
+          {error && (
+            <SupportingText isError hasErrorIcon message={error.message} />
           )}
         </div>
         <DescFormController form={form} variant={variant} />

--- a/src/shared/component/GroupInfoForm/index.tsx
+++ b/src/shared/component/GroupInfoForm/index.tsx
@@ -27,7 +27,8 @@ const GroupInfoForm = ({
   const handleSubmit = (_values: z.infer<typeof groupSchema>) => {
     // console.log({ values });
   };
-
+  const { startDate, endDate } = form.formState.errors;
+  const errors = startDate || endDate;
   return (
     <Form {...form}>
       <form
@@ -50,12 +51,8 @@ const GroupInfoForm = ({
               dateType="endDate"
             />
           </div>
-          {!!form.formState.errors.endDate && (
-            <SupportingText
-              isError
-              hasErrorIcon
-              message={form.formState.errors.endDate.message}
-            />
+          {!!errors && (
+            <SupportingText isError hasErrorIcon message={errors.message} />
           )}
         </div>
         <DescFormController form={form} variant={variant} />

--- a/src/shared/util/form.ts
+++ b/src/shared/util/form.ts
@@ -26,7 +26,9 @@ export const getMultipleRevalidationHandlers =
         field.onBlur();
         trigger(fieldNames);
       },
-      onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      onChange: (
+        e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | Date,
+      ) => {
         field.onChange(e);
         trigger(fieldNames);
       },
@@ -52,7 +54,9 @@ export const handleOnChangeMode = (
       field.onBlur();
       trigger(name);
     },
-    onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    onChange: (
+      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | Date,
+    ) => {
       field.onChange(e);
       trigger(name);
     },

--- a/src/view/user/create-group/CreateGroupForm/index.tsx
+++ b/src/view/user/create-group/CreateGroupForm/index.tsx
@@ -19,6 +19,8 @@ const CreateGroupForm = ({ setIsSuccess }: CreateGroupFormProps) => {
       image: "",
       name: "",
       desc: "",
+      startDate: new Date(),
+      endDate: new Date(),
     },
   });
 


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #133 

## ✅ Done Task
  - [x] 시작일, 종료일 수정 시 바로 반영되도록 수정
  - [x] edit avatar에 업로드한 이미지가 표시되도록 수정

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
- 값 반영
테스트 결과 값 반영은 문제가 없는 것으로 확인됐습니다.
그에 따라 다음 검사 후보인 zod의 유효성 검사 쪽을 확인했습니다.

- zod error
zod의 유효성 검사 결과로 나오는 에러는 에러가 발생한 필드만이 관여할 수 있습니다.
```typescript
export const groupSchema = z
  .object({
    image: z.string().nullable(),
    name: z
      .string()
      .min(1, { message: "필수 항목입니다." })
      .max(15, { message: "최대 15자까지 입력할 수 있습니다." }),
    startDate: z.date(),
    endDate: z.date(),
    desc: z.string(),
  })
.refine((data) => data.endDate >= data.startDate, {
   message: "종료 일자는 시작 일자보다 나중이어야 합니다.",
   path: ["endDate"],
 })
```
이 스키마는 모든 값이 존재하면 `refine`을 통해 값 검사를 하고 `errors.endDate`에 에러를 할당하는 기능을 하죠. 여기서 문제점은 `endDate`를 수정할 때만 에러가 할당된다는 점입니다. 
`startDate`를 수정하여 `endDate`보다 나중이 되게 만들면 `refine` 검사를 수행하여 에러 여부만 알 수 있을 뿐, `errors.endDate`는 수정하지 못합니다. 이를 통해 `refine`, `superRefine`은 수정한 필드의 error만 관여할 수 있는 것으로 확인됐습니다.
  - 문제 상황 설명 영상
  ![date1](https://github.com/user-attachments/assets/f73dfe57-e817-4278-8c2e-32b8c1a67ca2)

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 아바타 이미지 표시 문제
논리 연산자를 잘못 작성했어서 올바르게 수정했습니다.

- 캘린더 해결 순서
1. 일단 `defaultValues`에 두 Date를 추가해주었습니다. `DatePicker` 내부에서 자동으로 현재 날짜를 값으로 사용하긴 하지만 이 값이 자동으로 react-hook-form과 zod에 할당되진 않기 때문입니다.

    - default 없을 때 종료 일만 수정할 경우 에러 발생x
    ![image](https://github.com/user-attachments/assets/3ff0ce3d-8e15-47ae-9f5c-626766f7cca1)
    - 시작 일까지 값을 주고, 다시 종료 일을 수정하니 그제서야 에러 발생
    ![image](https://github.com/user-attachments/assets/bb6203dc-090e-4296-9cac-b91498d07eed)

2. error메세지 코드 수정
`form.formState.errors`를 비효율적으로 접근하고 있어서 잘 수정했습니다.

3. `FormController`에서 `Calendar`에 `revalidationHandler` 적용
타입 에러도 나고 쓸 일도 없을 것 같아서 달력에는 추가하지 않았었는데, `startDate` 필드를 수정하면 `endDate`도 검사하도록 만들기 위해 이걸 적용해야 되겠더군요. 그래서 타입 에러를 고치고 재검사 핸들러 함수를 적용할 수 있도록 수정했습니다.
적용 순서는 1. 기본 핸들러 2. 재검사 핸들러 순서로 되어야 하므로 제일 나중에 `revalidationHandler`를 할당합니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
- 어느 필드를 수정해도 검사 결과가 표시됨
![date2](https://github.com/user-attachments/assets/c4ec8ac5-c043-4a8e-b28e-bcbb07739efd)
