### PR TITLE
[ Init ] Ky 세팅 및 서버 통신 이상유무 확인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ next-env.d.ts
 
 *storybook.log
 *.mdx
+.env

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "date-fns": "^4.1.0",
     "framer-motion": "^11.7.0",
     "jotai": "^2.9.3",
+    "ky": "^1.7.2",
     "lottie-react": "^2.4.0",
     "next": "14.2.8",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       jotai:
         specifier: ^2.9.3
         version: 2.9.3(@types/react@18.3.5)(react@18.3.1)
+      ky:
+        specifier: ^1.7.2
+        version: 1.7.2
       lottie-react:
         specifier: ^2.4.0
         version: 2.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3316,6 +3319,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  ky@1.7.2:
+    resolution: {integrity: sha512-OzIvbHKKDpi60TnF9t7UUVAF1B4mcqc02z5PIvrm08Wyb+yOcz63GRvEuVxNT18a9E1SrNouhB4W2NNLeD7Ykg==}
+    engines: {node: '>=18'}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -8123,6 +8130,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  ky@1.7.2: {}
 
   lines-and-columns@1.2.4: {}
 

--- a/src/api/board/index.ts
+++ b/src/api/board/index.ts
@@ -1,0 +1,7 @@
+import { kyInstance } from "@/api";
+
+export const getBoard = async (boardId: number) => {
+  const response = await kyInstance.get(`board?boardId=${boardId}`).json();
+
+  return response;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,8 @@
+import ky from "ky";
+
+export const kyInstance = ky.create({
+  prefixUrl: process.env.NEXT_PUBLIC_HOST,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});

--- a/src/api/user/signIn/index.ts
+++ b/src/api/user/signIn/index.ts
@@ -1,0 +1,14 @@
+import { kyInstance } from "@/api";
+
+export const postSignin = async (email: string, password: string) => {
+  const response = await kyInstance
+    .post("api/user/sign-in", {
+      json: {
+        email,
+        password,
+      },
+    })
+    .json();
+
+  return response;
+};

--- a/src/api/user/signIn/index.ts
+++ b/src/api/user/signIn/index.ts
@@ -1,12 +1,10 @@
 import { kyInstance } from "@/api";
+import type { SignInRequest } from "@/api/user/type";
 
-export const postSignin = async (email: string, password: string) => {
+export const postSignin = async (formData: SignInRequest) => {
   const response = await kyInstance
     .post("api/user/sign-in", {
-      json: {
-        email,
-        password,
-      },
+      json: formData,
     })
     .json();
 

--- a/src/api/user/type.ts
+++ b/src/api/user/type.ts
@@ -1,4 +1,4 @@
-export type SignInResponse = {
+export type SignInRequest = {
   email: string;
   password: string;
 };


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #148 

## ✅ Done Task
  - [x] ky 세팅

## ☀️ New-insight

처음 사용해보는 라이브러리였습니다 ! 기본적으로 많이 사용하는 `axios`보다 훨씬 가볍고(`3.4KB`), 브라우저의 내장 API인 `fetch`와 사용법이 비슷하며, 인터셉터와 다양한 커스텀을 지원하는 [라이브러리](https://github.com/sindresorhus/ky?tab=readme-ov-file#kypostinput-options)입니다.

먼저 `instance`를 생성해주었습니다.

```ts
export const kyInstance = ky.create({
  prefixUrl: process.env.NEXT_PUBLIC_HOST,
  headers: {
    "Content-Type": "application/json",
  },
});
```

`axios`를 통해 인스턴스를 생성해줄 때와 아주 비슷했고, 단지 차이점은 `baseUrl` 대신에 `prefixUrl`이 들어간다는 점이겠네요. 또한 여기서 새롭게 알게된 점은 기본적으로 `next.js`에서 `env`를 사용할 때는 `node.js` 환경에서 돌아가기 때문에 자바스크립트 번들에 포함되지 않아 브라우저 상에서 동작하지 못합니다. 
따라서 브라우저에서도 코드를 통해 활용할 수 있도록 `NEXT_PUBLIC` 이라는 `prefix`를 붙히면 사용할 수 있습니다.

## 💎 PR Point

딱히 대단한 포인트는 없고, 인스턴스를 생성하였고 `signIn` api를 통해 간단한 테스트를 진행해보았습니다.

```ts
export const postSignin = async (formData: SignInRequest) => {
  const response = await kyInstance
    .post("api/user/sign-in", {
      json: formData,
    })
    .json();

  return response;
};
```
`api/user/signIn`에 작성한 fetch 함수입니다. 여기서 또 달랐던 점은 `axios`에서의 `body`를 `ky`에서는 `json`이라고 활용하더라구요 ! 이 점 유의해주시면 좋을 것 같습니다.
또한 `url` 파라미터로 들어가는 스트링은 `/`를 붙히면 안됩니다 ! 여기서 에러가 발생하여서 이게 무슨 에러인지 찾아내느라 시간이 조금 걸렸는데 `ky`는 앞에 자동으로 `/`를 붙혀주는 것 같습니다.
따라서 아래와 같이 사용하게 됩니다.
```
post("api/user", ... ) // O
post("/api/user", ...) // X
```

정상적으로 토큰 받아와지는 것 확인했습니다 !
