### PR TITLE
[ Fix ] table 스타일링 방식 변경

### DIFF
--- a/src/shared/component/Table/Table.stories.tsx
+++ b/src/shared/component/Table/Table.stories.tsx
@@ -4,7 +4,11 @@ import { theme } from "@/styles/themes.css";
 import { ALARM_SETTINGS_COLUMNS } from "@/view/user/setting/AlarmSetting/AlarmSettingTable/constant";
 import { tdStyle } from "@/view/user/setting/AlarmSetting/AlarmSettingTable/index.css";
 import { STUDY_LIST_COLUMNS } from "@/view/user/setting/StudyList/StudyListTable/constant";
-import { tableCaptionStyle, tableStyle, theadStyle } from "@/view/user/setting/StudyList/StudyListTable/index.css";
+import {
+  tableCaptionStyle,
+  tableStyle,
+  theadStyle,
+} from "@/view/user/setting/StudyList/StudyListTable/index.css";
 import type { Meta } from "@storybook/react";
 import { DataTable } from ".";
 

--- a/src/shared/component/Table/Table.stories.tsx
+++ b/src/shared/component/Table/Table.stories.tsx
@@ -2,7 +2,9 @@ import { AlarmSettingsData, StudyListData } from "@/shared/constant/example";
 import { theme } from "@/styles/themes.css";
 
 import { ALARM_SETTINGS_COLUMNS } from "@/view/user/setting/AlarmSetting/AlarmSettingTable/constant";
+import { tdStyle } from "@/view/user/setting/AlarmSetting/AlarmSettingTable/index.css";
 import { STUDY_LIST_COLUMNS } from "@/view/user/setting/StudyList/StudyListTable/constant";
+import { tableCaptionStyle, tableStyle, theadStyle } from "@/view/user/setting/StudyList/StudyListTable/index.css";
 import type { Meta } from "@storybook/react";
 import { DataTable } from ".";
 
@@ -29,9 +31,11 @@ export const StudyList = {
     return (
       <DataTable
         title="스터디 리스트"
-        type="스터디리스트"
         rows={StudyListData}
         cols={STUDY_LIST_COLUMNS}
+        tableClassName={tableStyle}
+        captionClassName={tableCaptionStyle}
+        theadClassName={theadStyle}
       />
     );
   },
@@ -41,9 +45,11 @@ export const AlarmSetting = {
   render: () => {
     return (
       <DataTable
-        type="알림설정"
         rows={AlarmSettingsData}
         cols={ALARM_SETTINGS_COLUMNS}
+        tableClassName={tableStyle}
+        theadClassName={theadStyle}
+        tdClassName={tdStyle}
       />
     );
   },

--- a/src/shared/component/Table/TableElements/Body.tsx
+++ b/src/shared/component/Table/TableElements/Body.tsx
@@ -1,25 +1,26 @@
-import type { TableDataType, TableType } from "@/shared/type/table";
+import type { TableDataType } from "@/shared/type/table";
+import clsx from "clsx";
 import TableCell from "./TableCell";
 import { tableCellTextStyle, tableRowStyle } from "./index.css";
 
 type BodyProps<T> = {
-  type: TableType;
   rows: T[];
   cols: TableDataType<T>[];
+  trClassName?: string;
+  tdClassName?: string;
 };
 
-const Body = <T,>({ rows, cols, type }: BodyProps<T>) => {
+const Body = <T,>({ rows, cols, trClassName, tdClassName }: BodyProps<T>) => {
   return (
     <tbody>
       {rows.map((row, idx) => (
         // TODO: api 연결 후, raw data에 고유 id값 추가 등의 방안으로 key 교체하기
-        <tr key={idx} className={tableRowStyle}>
+        <tr key={idx} className={clsx(trClassName, tableRowStyle)}>
           {cols.map(({ key, align, Cell }) => (
             <TableCell
               key={key?.toString()}
               align={align}
-              type={type}
-              className={tableCellTextStyle[type]}
+              className={clsx(tableCellTextStyle, tdClassName)}
             >
               {Cell(row)}
             </TableCell>

--- a/src/shared/component/Table/TableElements/Header.tsx
+++ b/src/shared/component/Table/TableElements/Header.tsx
@@ -1,20 +1,30 @@
 import { headWrapper } from "@/shared/component/Table/index.css";
-import type { TableDataType, TableType } from "@/shared/type/table";
+import type { TableDataType } from "@/shared/type/table";
+import clsx from "clsx";
 import { memo } from "react";
 import TableHead from "./TableHead";
 import { tableHeaderStyle } from "./index.css";
 
 type HeaderProps<T> = {
   columns: TableDataType<T>[];
-  type: TableType;
+  theadClassName?: string;
+  thClassName?: string;
 };
 
-const Header = <T,>({ columns, type }: HeaderProps<T>) => {
+const Header = <T,>({
+  columns,
+  theadClassName,
+  thClassName,
+}: HeaderProps<T>) => {
   return (
-    <thead className={tableHeaderStyle({ type })}>
+    <thead className={clsx(theadClassName, tableHeaderStyle)}>
       <tr>
-        {columns.map(({ key, Header, width, align, props }) => (
-          <TableHead key={key?.toString()} {...props} width={width}>
+        {columns.map(({ key, Header, width, align }) => (
+          <TableHead
+            key={key?.toString()}
+            className={thClassName}
+            width={width}
+          >
             <div className={headWrapper({ align })}>
               <Header />
             </div>

--- a/src/shared/component/Table/TableElements/TableCell.tsx
+++ b/src/shared/component/Table/TableElements/TableCell.tsx
@@ -1,14 +1,12 @@
-import type { TableType } from "@/shared/type/table";
 import clsx from "clsx";
 import type { ComponentProps } from "react";
 import { tableCellStyle } from "./index.css";
 
 type TableCellProps = {
   align?: "left" | "right";
-  type: TableType;
 } & ComponentProps<"td">;
 
-const TableCell = ({ className, align, type, ...props }: TableCellProps) => (
-  <td className={clsx(tableCellStyle({ align, type }), className)} {...props} />
+const TableCell = ({ className, align, ...props }: TableCellProps) => (
+  <td className={clsx(tableCellStyle({ align }), className)} {...props} />
 );
 export default TableCell;

--- a/src/shared/component/Table/TableElements/TableHead.tsx
+++ b/src/shared/component/Table/TableElements/TableHead.tsx
@@ -7,12 +7,7 @@ type TableHeadProps = {
   width?: number;
 } & ComponentProps<"th">;
 
-const TableHead = ({
-  className,
-  align,
-  width,
-  ...props
-}: TableHeadProps) => {
+const TableHead = ({ className, align, width, ...props }: TableHeadProps) => {
   return (
     <th
       className={clsx(tableHeadStyle({ align }), className)}

--- a/src/shared/component/Table/TableElements/TableHead.tsx
+++ b/src/shared/component/Table/TableElements/TableHead.tsx
@@ -1,17 +1,14 @@
-import type { TableType } from "@/shared/type/table";
 import clsx from "clsx";
 import type { ComponentProps } from "react";
 import { tableHeadStyle } from "./index.css";
 
 type TableHeadProps = {
   align?: "left" | "right";
-  type?: TableType;
   width?: number;
 } & ComponentProps<"th">;
 
 const TableHead = ({
   className,
-  type,
   align,
   width,
   ...props

--- a/src/shared/component/Table/TableElements/index.css.ts
+++ b/src/shared/component/Table/TableElements/index.css.ts
@@ -11,6 +11,7 @@ export const wrapperStyle = style({
   overflow: "auto",
 
   width: "100%",
+  // scroll bar 막대 감추기
   "::-webkit-scrollbar": {
     width: 0,
   },
@@ -49,19 +50,6 @@ export const tableStyle = style({
   width: "90%",
 
   captionSide: "top",
-  // variants: {
-  //   type: {
-  //     스터디리스트: {
-  //       borderCollapse: "separate",
-  //       borderSpacing: "0 1.6rem",
-  //     },
-  //     알림설정: {
-  //       borderCollapse: "collapse",
-
-  //       width: "92.5%",
-  //     },
-  //   },
-  // },
 });
 
 export const tableCaptionStyle = style({
@@ -70,56 +58,10 @@ export const tableCaptionStyle = style({
   fontSize: "1.6rem",
   fontWeight: 600,
   lineHeight: "19.09px",
-  // variants: {
-  //   type: {
-  //     스터디리스트: {
-  //       position: "sticky",
-  //       top: 0,
-  //       zIndex: theme.zIndex.bottom,
-
-  //       padding: "1.5rem 0",
-  //       background: theme.color.bg,
-  //     },
-  //     알림설정: {
-  //       padding: "1.5rem 2rem",
-  //     },
-  //   },
-  // },
 });
 
 export const tableHeaderStyle = style({
   position: "relative",
-  // variants: {
-  //   type: {
-  //     스터디리스트: {
-  //       position: "sticky",
-  //       top: "6.6rem",
-  //       zIndex: theme.zIndex.bottom,
-
-  //       height: "3.6rem",
-  //       verticalAlign: "top",
-  //       ":after": {
-  //         content: "",
-
-  //         position: "absolute",
-  //         bottom: 0,
-  //         left: 0,
-  //         zIndex: 0,
-
-  //         width: "100%",
-  //         height: "1px",
-  //         backgroundColor: "#2D3239",
-  //       },
-  //     },
-  //     알림설정: {
-  //       height: "4.1rem",
-
-  //       backgroundColor: theme.color.mg5,
-  //       borderTopLeftRadius: "4px",
-  //       borderTopRightRadius: "4px",
-  //     },
-  //   },
-  // },
 });
 
 export const tableRowStyle = style({
@@ -146,24 +88,10 @@ export const tableCellStyle = recipe({
         paddingRight: "1.2rem",
       },
     },
-    // type: {
-    //   스터디리스트: {
-    //     height: "4.6rem",
-    //   },
-    //   알림설정: {
-    //     height: "4.8rem",
-    //     borderBottom: `1px solid ${theme.color.mg5}`,
-    //   },
-    // },
   },
 });
 
 export const tableCellTextStyle = style({
   ...theme.font.Caption3_M_12,
   color: theme.color.white,
-  // },
-  // 알림설정: {
-  //   ...theme.font.Caption3_M_12,
-  //   color: theme.color.mg2,
-  // },
 });

--- a/src/shared/component/Table/TableElements/index.css.ts
+++ b/src/shared/component/Table/TableElements/index.css.ts
@@ -1,5 +1,5 @@
 import { theme } from "@/styles/themes.css";
-import { style, styleVariants } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
 export const wrapperStyle = style({
@@ -32,11 +32,6 @@ export const tableHeadStyle = recipe({
         textAlign: "right",
       },
     },
-    padding: {
-      dense: {
-        padding: "0 2rem",
-      },
-    },
   },
 });
 
@@ -50,87 +45,81 @@ export const withdrawTextStyle = style({
   },
 });
 
-export const tableStyle = recipe({
-  base: {
-    width: "90%",
+export const tableStyle = style({
+  width: "90%",
 
-    captionSide: "top",
-  },
-  variants: {
-    type: {
-      스터디리스트: {
-        borderCollapse: "separate",
-        borderSpacing: "0 1.6rem",
-      },
-      알림설정: {
-        borderCollapse: "collapse",
+  captionSide: "top",
+  // variants: {
+  //   type: {
+  //     스터디리스트: {
+  //       borderCollapse: "separate",
+  //       borderSpacing: "0 1.6rem",
+  //     },
+  //     알림설정: {
+  //       borderCollapse: "collapse",
 
-        width: "92.5%",
-      },
-    },
-  },
+  //       width: "92.5%",
+  //     },
+  //   },
+  // },
 });
 
-export const tableCaptionStyle = recipe({
-  base: {
-    color: theme.color.white,
-    textAlign: "left",
-    fontSize: "1.6rem",
-    fontWeight: 600,
-    lineHeight: "19.09px",
-  },
-  variants: {
-    type: {
-      스터디리스트: {
-        position: "sticky",
-        top: 0,
-        zIndex: theme.zIndex.bottom,
+export const tableCaptionStyle = style({
+  color: theme.color.white,
+  textAlign: "left",
+  fontSize: "1.6rem",
+  fontWeight: 600,
+  lineHeight: "19.09px",
+  // variants: {
+  //   type: {
+  //     스터디리스트: {
+  //       position: "sticky",
+  //       top: 0,
+  //       zIndex: theme.zIndex.bottom,
 
-        padding: "1.5rem 0",
-        background: theme.color.bg,
-      },
-      알림설정: {
-        padding: "1.5rem 2rem",
-      },
-    },
-  },
+  //       padding: "1.5rem 0",
+  //       background: theme.color.bg,
+  //     },
+  //     알림설정: {
+  //       padding: "1.5rem 2rem",
+  //     },
+  //   },
+  // },
 });
 
-export const tableHeaderStyle = recipe({
-  base: {
-    position: "relative",
-  },
-  variants: {
-    type: {
-      스터디리스트: {
-        position: "sticky",
-        top: "6.6rem",
-        zIndex: theme.zIndex.bottom,
+export const tableHeaderStyle = style({
+  position: "relative",
+  // variants: {
+  //   type: {
+  //     스터디리스트: {
+  //       position: "sticky",
+  //       top: "6.6rem",
+  //       zIndex: theme.zIndex.bottom,
 
-        height: "3.6rem",
-        verticalAlign: "top",
-        ":after": {
-          content: "",
+  //       height: "3.6rem",
+  //       verticalAlign: "top",
+  //       ":after": {
+  //         content: "",
 
-          position: "absolute",
-          bottom: 0,
-          left: 0,
-          zIndex: 0,
+  //         position: "absolute",
+  //         bottom: 0,
+  //         left: 0,
+  //         zIndex: 0,
 
-          width: "100%",
-          height: "1px",
-          backgroundColor: "#2D3239",
-        },
-      },
-      알림설정: {
-        height: "4.1rem",
+  //         width: "100%",
+  //         height: "1px",
+  //         backgroundColor: "#2D3239",
+  //       },
+  //     },
+  //     알림설정: {
+  //       height: "4.1rem",
 
-        backgroundColor: theme.color.mg5,
-        borderTopLeftRadius: "4px",
-        borderTopRightRadius: "4px",
-      },
-    },
-  },
+  //       backgroundColor: theme.color.mg5,
+  //       borderTopLeftRadius: "4px",
+  //       borderTopRightRadius: "4px",
+  //     },
+  //   },
+  // },
 });
 
 export const tableRowStyle = style({
@@ -157,25 +146,24 @@ export const tableCellStyle = recipe({
         paddingRight: "1.2rem",
       },
     },
-    type: {
-      스터디리스트: {
-        height: "4.6rem",
-      },
-      알림설정: {
-        height: "4.8rem",
-        borderBottom: `1px solid ${theme.color.mg5}`,
-      },
-    },
+    // type: {
+    //   스터디리스트: {
+    //     height: "4.6rem",
+    //   },
+    //   알림설정: {
+    //     height: "4.8rem",
+    //     borderBottom: `1px solid ${theme.color.mg5}`,
+    //   },
+    // },
   },
 });
 
-export const tableCellTextStyle = styleVariants({
-  스터디리스트: {
-    ...theme.font.Caption3_M_12,
-    color: theme.color.white,
-  },
-  알림설정: {
-    ...theme.font.Caption3_M_12,
-    color: theme.color.mg2,
-  },
+export const tableCellTextStyle = style({
+  ...theme.font.Caption3_M_12,
+  color: theme.color.white,
+  // },
+  // 알림설정: {
+  //   ...theme.font.Caption3_M_12,
+  //   color: theme.color.mg2,
+  // },
 });

--- a/src/shared/component/Table/index.tsx
+++ b/src/shared/component/Table/index.tsx
@@ -1,5 +1,6 @@
 "use client";
-import type { TableDataType, TableType } from "@/shared/type/table";
+import type { TableDataType } from "@/shared/type/table";
+import clsx from "clsx";
 import Body from "./TableElements/Body";
 import Header from "./TableElements/Header";
 import {
@@ -11,28 +12,52 @@ import {
 type DataTableProps<T> = {
   /** 좌상단 제목 */
   title?: string;
-  /** 테이블 타입: 테이블 내부 요소들에서 recipe()로 스타일 변경 */
-  type: TableType;
   /** 원본 데이터 배열 */
   rows: T[];
   /** 테이블 메타데이터(행, 열) 배열 */
   cols: TableDataType<T>[];
+
+  wrapperClassName?: string;
+  tableClassName?: string;
+  captionClassName?: string;
+  theadClassName?: string;
+  thClassName?: string;
+  /** tbody의 tr만 적용. thead의 tr은 적용되지 않음 */
+  trClassName?: string;
+  tdClassName?: string;
 };
 
 export const DataTable = <T,>({
   title,
-  type,
   rows,
   cols,
+  wrapperClassName,
+  tableClassName,
+  captionClassName,
+  theadClassName,
+  thClassName,
+  trClassName,
+  tdClassName,
 }: DataTableProps<T>) => {
   return (
-    <div className={wrapperStyle}>
-      <table className={tableStyle({ type })}>
+    <div className={clsx(wrapperStyle, wrapperClassName)}>
+      <table className={clsx(tableClassName, tableStyle)}>
         {title && (
-          <caption className={tableCaptionStyle({ type })}>{title}</caption>
+          <caption className={clsx(captionClassName, tableCaptionStyle)}>
+            {title}
+          </caption>
         )}
-        <Header columns={cols} type={type} />
-        <Body rows={rows} cols={cols} type={type} />
+        <Header
+          columns={cols}
+          theadClassName={theadClassName}
+          thClassName={thClassName}
+        />
+        <Body
+          rows={rows}
+          cols={cols}
+          trClassName={trClassName}
+          tdClassName={tdClassName}
+        />
       </table>
     </div>
   );

--- a/src/shared/type/table.ts
+++ b/src/shared/type/table.ts
@@ -1,13 +1,9 @@
-import type { ComponentProps, FC } from "react";
-import type TableHead from "../component/Table/TableElements/TableHead";
-
-export type TableType = "스터디리스트" | "알림설정";
+import type { FC } from "react";
 
 export type TableDataType<T> = {
   key: keyof T | string | undefined;
   Header: FC;
   Cell: FC<T>;
-  props?: ComponentProps<typeof TableHead>;
   align?: "left" | "right";
   width: number;
 };

--- a/src/view/user/setting/AlarmSetting/AlarmSettingTable/index.css.ts
+++ b/src/view/user/setting/AlarmSetting/AlarmSettingTable/index.css.ts
@@ -1,4 +1,5 @@
 import { theme } from "@/styles/themes.css";
+import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
 export const textStyle = recipe({
@@ -15,4 +16,25 @@ export const textStyle = recipe({
       },
     },
   },
+});
+
+export const tableStyle = style({
+  borderCollapse: "collapse",
+
+  width: "92.5%",
+});
+
+export const theadStyle = style({
+  height: "4.1rem",
+
+  backgroundColor: theme.color.mg5,
+  borderTopLeftRadius: "4px",
+  borderTopRightRadius: "4px",
+});
+
+export const tdStyle = style({
+  height: "4.8rem",
+  borderBottom: `1px solid ${theme.color.mg5}`,
+
+  color: theme.color.mg2,
 });

--- a/src/view/user/setting/AlarmSetting/AlarmSettingTable/index.tsx
+++ b/src/view/user/setting/AlarmSetting/AlarmSettingTable/index.tsx
@@ -1,13 +1,16 @@
 import { DataTable } from "@/shared/component/Table";
 import { AlarmSettingsData } from "@/shared/constant/example";
 import { ALARM_SETTINGS_COLUMNS } from "./constant";
+import { tableStyle, tdStyle, theadStyle } from "./index.css";
 
 const AlarmSettingTable = () => {
   return (
     <DataTable
-      type="알림설정"
       cols={ALARM_SETTINGS_COLUMNS}
       rows={AlarmSettingsData}
+      tableClassName={tableStyle}
+      theadClassName={theadStyle}
+      tdClassName={tdStyle}
     />
   );
 };

--- a/src/view/user/setting/StudyList/StudyListTable/constant.tsx
+++ b/src/view/user/setting/StudyList/StudyListTable/constant.tsx
@@ -79,17 +79,11 @@ export const STUDY_LIST_COLUMNS: TableDataType<StudyListType>[] = [
       const endDateStr = format(endDate, "yyyy-MM-dd");
       return (
         <>
-          <time
-            className={tableCellTextStyle.스터디리스트}
-            dateTime={startDateStr}
-          >
+          <time className={tableCellTextStyle} dateTime={startDateStr}>
             {startDateStr}
           </time>{" "}
           ~{" "}
-          <time
-            className={tableCellTextStyle.스터디리스트}
-            dateTime={endDateStr}
-          >
+          <time className={tableCellTextStyle} dateTime={endDateStr}>
             {endDateStr}
           </time>
         </>

--- a/src/view/user/setting/StudyList/StudyListTable/index.css.ts
+++ b/src/view/user/setting/StudyList/StudyListTable/index.css.ts
@@ -1,0 +1,38 @@
+import { theme } from "@/styles/themes.css";
+import { style } from "@vanilla-extract/css";
+
+export const tableStyle = style({
+  borderCollapse: "separate",
+  borderSpacing: "0 1.6rem",
+});
+
+export const tableCaptionStyle = style({
+  position: "sticky",
+  top: 0,
+  zIndex: theme.zIndex.bottom,
+  padding: "1.5rem 0",
+  background: theme.color.bg,
+});
+
+export const theadStyle = style({
+  position: "sticky",
+  top: "6.6rem",
+  zIndex: theme.zIndex.bottom,
+
+  height: "3.6rem",
+
+  verticalAlign: "top",
+
+  ":after": {
+    content: "",
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    zIndex: 0,
+
+    width: "100%",
+    height: "1px",
+
+    backgroundColor: "#2D3239",
+  },
+});

--- a/src/view/user/setting/StudyList/StudyListTable/index.tsx
+++ b/src/view/user/setting/StudyList/StudyListTable/index.tsx
@@ -1,6 +1,7 @@
 import { DataTable } from "@/shared/component/Table";
 import { STUDY_LIST_COLUMNS } from "./constant";
 import { useStudyListData } from "./hook";
+import { tableCaptionStyle, tableStyle, theadStyle } from "./index.css";
 
 const StudyListTable = () => {
   const data = useStudyListData();
@@ -8,9 +9,11 @@ const StudyListTable = () => {
   return (
     <DataTable
       title="스터디 리스트"
-      type="스터디리스트"
       rows={data}
       cols={STUDY_LIST_COLUMNS}
+      tableClassName={tableStyle}
+      captionClassName={tableCaptionStyle}
+      theadClassName={theadStyle}
     />
   );
 };


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #150 

## ✅ Done Task
  - [x] 테이블 스타일링 방식만 교체
  - [x] 마이페이지 테이블 2개 마이그레이션

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
props 연결은 좀 귀찮았지만 바꾸고 나니 스타일링 방식이 직관적이라 좋네요.
## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 테이블 타입 변경
기존에 `recipe`을 활용한 스타일링을 위해 지정해야 했던 `type` 프로퍼티가 제거되고 테이블 내부 요소들의 `className`을 선택적으로 받습니다. clsx를 사용하여 병합되니 기본 스타일이 어떤지 먼저 확인한 뒤에 className을 추가하는 것을 추천드립니다.
    ```typescript
    type DataTableProps<T> = {
      /** 좌상단 제목 */
      title?: string;
      /** 원본 데이터 배열 */
      rows: T[];
      /** 테이블 메타데이터(행, 열) 배열 */
      cols: TableDataType<T>[];
    
      wrapperClassName?: string;  // `<table>`을 감싸는 div.wrapper
      tableClassName?: string; // `<table>` 태그의 className
      captionClassName?: string; // `<caption>`태그의 className
      theadClassName?: string; // 이하 동일
      thClassName?: string;
      /** tbody의 tr만 적용. thead의 tr은 적용되지 않음 */
      trClassName?: string;
      tdClassName?: string;
    };
    ```
- 사용 방법(스타일링)
처음에 `className`들은 넣지 않고 `rows`, `cols`만 먼저 넣은 뒤에 어디에 스타일을 줘야 할 지 확인해서 추가해나가면 되겠습니다.
    ```tsx
    // css.ts
    export const tableStyle = style({...})
    export const tableCaptionStyle = style({...})
    export const theadStyle = style({...})
    
    // table
    <DataTable
      title="스터디 리스트"
      rows={data}
      cols={STUDY_LIST_COLUMNS}
      tableClassName={tableStyle}
      captionClassName={tableCaptionStyle}
      theadClassName={theadStyle}
    />
    ```
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->