### PR TITLE
[ Feat ] Notice 모달 Detail의 코멘트 부분 퍼블리싱

### DIFF
--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -5,6 +5,7 @@ import type { Problem } from "@/shared/type";
 import { tmpGroupData } from "@/shared/util/example";
 import { sidebarWrapper } from "@/styles/shared.css";
 import GroupSidebar from "@/view/group/dashboard/GroupSidebar";
+import NoticeBanner from "@/view/group/dashboard/NoticeBanner";
 import Ranking from "@/view/group/dashboard/Ranking";
 
 const GroupDashboardPage = () => {
@@ -50,6 +51,7 @@ const GroupDashboardPage = () => {
         <GroupSidebar info={tmpGroupData} />
       </Sidebar>
       <div className={listSectionStyle}>
+        <NoticeBanner />
         <Ranking />
         <h2 className={titleStyle}>풀어야 할 문제</h2>
         <section>

--- a/src/shared/component/CommentBox/index.tsx
+++ b/src/shared/component/CommentBox/index.tsx
@@ -15,11 +15,13 @@ import {
 import useA11yHoverHandler from "@/shared/hook/useA11yHandler";
 import type { Comment } from "@/shared/type/comment";
 import { getFormattedCreatedAt } from "@/shared/util/time";
+import clsx from "clsx";
 
 type CommentBox = Comment & {
   variant: "detail" | "notice";
   onDelete?: () => void;
   onEdit?: () => void;
+  className?: string;
 };
 
 const CommentBox = ({
@@ -31,6 +33,7 @@ const CommentBox = ({
   createdAt,
   onDelete,
   onEdit,
+  className,
 }: CommentBox) => {
   const { isActive, handleFocus, handleBlur, handleMouseOver, handleMouseOut } =
     useA11yHoverHandler();
@@ -42,7 +45,7 @@ const CommentBox = ({
       onMouseOver={handleMouseOver}
       onMouseLeave={handleMouseOut}
       aria-label={`코멘트 ${commentId}`}
-      className={containerStyle({ isActive })}
+      className={clsx(containerStyle({ isActive }), className)}
     >
       <Avatar
         src={writerProfileImage}

--- a/src/view/group/dashboard/NoticeModal/NoticeDetail/index.css.ts
+++ b/src/view/group/dashboard/NoticeModal/NoticeDetail/index.css.ts
@@ -1,4 +1,4 @@
-import { theme } from "@/styles/themes.css";
+import { scrollTheme, theme } from "@/styles/themes.css";
 import { style, styleVariants } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
@@ -114,6 +114,19 @@ export const iconStyle = recipe({
       },
     },
   },
+});
+
+export const listStyle = style({
+  width: "100%",
+  height: "13.2rem",
+
+  overflowY: "scroll",
+
+  ...scrollTheme.scrollbar,
+});
+
+export const itemStyle = style({
+  borderBottom: `1px solid ${theme.color.mg5}`,
 });
 
 export const textStyle = styleVariants({

--- a/src/view/group/dashboard/NoticeModal/NoticeDetail/index.css.ts
+++ b/src/view/group/dashboard/NoticeModal/NoticeDetail/index.css.ts
@@ -60,7 +60,7 @@ export const textareaWrapper = style({
 });
 
 export const textareaStyle = style({
-  height: "21.8rem",
+  height: "18rem",
 });
 
 export const inputStyle = style({
@@ -118,7 +118,7 @@ export const iconStyle = recipe({
 
 export const listStyle = style({
   width: "100%",
-  height: "13.2rem",
+  height: "15rem",
 
   overflowY: "scroll",
 

--- a/src/view/group/dashboard/NoticeModal/NoticeDetail/index.css.ts
+++ b/src/view/group/dashboard/NoticeModal/NoticeDetail/index.css.ts
@@ -60,7 +60,7 @@ export const textareaWrapper = style({
 });
 
 export const textareaStyle = style({
-  height: "18rem",
+  height: "20rem",
 });
 
 export const inputStyle = style({
@@ -118,7 +118,7 @@ export const iconStyle = recipe({
 
 export const listStyle = style({
   width: "100%",
-  height: "15rem",
+  height: "21rem",
 
   overflowY: "scroll",
 

--- a/src/view/group/dashboard/NoticeModal/NoticeDetail/index.tsx
+++ b/src/view/group/dashboard/NoticeModal/NoticeDetail/index.tsx
@@ -1,7 +1,9 @@
+import type { CommentContent } from "@/api/comment/type";
 import type { NoticeResponse } from "@/api/notice/type";
 import { IcnClose, IcnEdit, IcnNew } from "@/asset/svg";
 import Avatar from "@/common/component/Avatar";
 import Textarea from "@/common/component/Textarea";
+import CommentBox from "@/shared/component/CommentBox";
 import CommentInput from "@/shared/component/CommentInput";
 import useA11yHoverHandler from "@/shared/hook/useA11yHandler";
 import { getNoticeBannerCreateAt } from "@/shared/util/time";
@@ -15,6 +17,8 @@ import {
   iconContainerStyle,
   iconStyle,
   inputStyle,
+  itemStyle,
+  listStyle,
   noticeInfoStyle,
   textStyle,
   textareaStyle,
@@ -52,6 +56,17 @@ const NoticeDetail = ({
     // TODO: 삭제 안내 창 띄우기
     goBack();
   };
+
+  /** TODO: 실제 Comment API로 연결 */
+  const tmpData: CommentContent = {
+    commentId: 1,
+    writerNickname: "고독한 예린",
+    writerProfileImage: "",
+    createAt: "2024-10-24",
+    content:
+      "이 접근 방식이 문제를 해결하는 데 충분히 효율적일까요? 추가적인 최적화 방법이 있을까요?",
+  };
+
   return (
     <article
       className={articleStyle}
@@ -111,8 +126,19 @@ const NoticeDetail = ({
       </div>
 
       {/* 댓글란 */}
-      <ul>
-        <></>
+      <ul className={listStyle}>
+        {[tmpData, tmpData, tmpData].map((item, idx) => (
+          <CommentBox
+            key={item.commentId}
+            className={idx !== 2 ? itemStyle : ""}
+            variant="notice"
+            commentId={item.commentId}
+            createdAt={item.createAt}
+            content={item.content}
+            writerNickname={item.writerNickname}
+            writerProfileImage={item.writerProfileImage}
+          />
+        ))}
       </ul>
 
       {/* 댓글 입력란 */}

--- a/src/view/group/dashboard/NoticeModal/NoticeDetail/index.tsx
+++ b/src/view/group/dashboard/NoticeModal/NoticeDetail/index.tsx
@@ -127,7 +127,7 @@ const NoticeDetail = ({
 
       {/* 댓글란 */}
       <ul className={listStyle}>
-        {[tmpData, tmpData, tmpData].map((item, idx) => (
+        {[tmpData, tmpData, tmpData, tmpData].map((item, idx) => (
           <CommentBox
             key={item.commentId}
             className={idx !== 2 ? itemStyle : ""}

--- a/src/view/group/dashboard/NoticeModal/index.css.ts
+++ b/src/view/group/dashboard/NoticeModal/index.css.ts
@@ -3,7 +3,7 @@ import { style } from "@vanilla-extract/css";
 
 export const noticeModalWrapper = style({
   width: "100rem",
-  height: "60rem",
+  height: "70rem",
   padding: "3.6rem 2.4rem",
 
   backgroundColor: theme.color.bg,


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #154 

## ✅ Done Task
  - [x] 코멘트 퍼블리싱

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

단순 퍼블리싱이였습니다 ! 

<img width="457" alt="image" src="https://github.com/user-attachments/assets/725096ce-cce1-459a-b81b-5c3dccc1153d">

사진에서 볼 수 있다시피, GUI는 위에 있는 `item`의 `borderBottom`이 아래에 있는 아이템에 딱 붙어있는 상태입니다. 이것보다는 패딩을 동일하게 설정하고 각 아이템의 `border`가 컨텐츠에 모두 떨어져있는 것이 더 좋을 것 같아서 반영하였습니다.

따라서 실제 코멘트가 표시되는 컨테이너 요소의 `height`는 `GUI`상 `11.6rem` 이였는데, `borderBottom`을 컨텐츠 사이랑 띄우게 되면 `1.6rem`이 추가되어야 해서 `13.2rem`으로 맞추었습니다.

## 📸 Screenshot


https://github.com/user-attachments/assets/d4c67e7d-75a5-424f-9199-b1e17f1d74ae

