### PR TITLE
[ Fix ] 내 정보 불러오기 API 데이터 패칭 오류 해결

### DIFF
--- a/src/shared/component/Header/Logo.tsx
+++ b/src/shared/component/Header/Logo.tsx
@@ -1,16 +1,21 @@
 "use client";
 
+import type { UserResponse } from "@/api/users/type";
 import { IcnLogo } from "@/asset/svg";
 import { logoContainer, logoStyle } from "@/shared/component/Header/index.css";
 import Link from "next/link";
 
 type LogoProps = {
-  user: string;
+  user: UserResponse;
 };
 
 const Logo = ({ user }: LogoProps) => {
   return (
-    <Link href={`/${user}`} className={logoContainer} aria-label="User page">
+    <Link
+      href={`/${user.nickname}`}
+      className={logoContainer}
+      aria-label="User page"
+    >
       <IcnLogo className={logoStyle} aria-label="algoHub 로고" />
     </Link>
   );

--- a/src/shared/component/Header/Logo.tsx
+++ b/src/shared/component/Header/Logo.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { IcnLogo } from "@/asset/svg";
+import { logoContainer, logoStyle } from "@/shared/component/Header/index.css";
+import Link from "next/link";
+
+type LogoProps = {
+  user: string;
+};
+
+const Logo = ({ user }: LogoProps) => {
+  return (
+    <Link href={`/${user}`} className={logoContainer} aria-label="User page">
+      <IcnLogo className={logoStyle} aria-label="algoHub 로고" />
+    </Link>
+  );
+};
+
+export default Logo;

--- a/src/shared/component/Header/index.tsx
+++ b/src/shared/component/Header/index.tsx
@@ -1,27 +1,20 @@
-"use client";
-
 import { getNotificationList } from "@/api/notifications";
-import { useMyNicknameQuery } from "@/app/[user]/query";
-import { IcnLogo } from "@/asset/svg";
+import { getMyInfo } from "@/api/users";
+import Logo from "@/shared/component/Header/Logo";
 import UserMenu from "@/shared/component/Header/UserMenu";
-import {
-  headerStyle,
-  logoContainer,
-  logoStyle,
-} from "@/shared/component/Header/index.css";
+import { headerStyle } from "@/shared/component/Header/index.css";
 import LoginMenu from "@/view/login/LoginMenu/LoginMenu";
 import {
   HydrationBoundary,
   QueryClient,
   dehydrate,
 } from "@tanstack/react-query";
-import Link from "next/link";
 
 const Header = async () => {
   /* TODO: 로그인 api 부착 후 Atom으로 교체 */
   // const { isLoggedIn } = useAtomValue(authAtom);
   const isLoggedIn = true;
-  const userNickname = useMyNicknameQuery();
+  const userNickname = await getMyInfo();
 
   const queryClient = new QueryClient();
 
@@ -32,13 +25,7 @@ const Header = async () => {
 
   return (
     <header className={headerStyle}>
-      <Link
-        href={`/${userNickname}`}
-        className={logoContainer}
-        aria-label="User page"
-      >
-        <IcnLogo className={logoStyle} aria-label="algoHub 로고" />
-      </Link>
+      <Logo user={userNickname.nickname!} />
       <HydrationBoundary state={dehydrate(queryClient)}>
         {isLoggedIn ? <UserMenu /> : <LoginMenu />}
       </HydrationBoundary>

--- a/src/shared/component/Header/index.tsx
+++ b/src/shared/component/Header/index.tsx
@@ -25,7 +25,7 @@ const Header = async () => {
 
   return (
     <header className={headerStyle}>
-      <Logo user={userNickname.nickname!} />
+      <Logo user={userNickname} />
       <HydrationBoundary state={dehydrate(queryClient)}>
         {isLoggedIn ? <UserMenu /> : <LoginMenu />}
       </HydrationBoundary>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #229 

## ✅ Done Task
  - [x] query -> ssg

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

`Header` 컴포넌트에서 `async` `await`으로 처리되어 있으나, 안에서 `useQuery`를 사용하고 있어서 에러가 발생하는거더라구요 !
`use client` 지워주고 `SSG`로 데이터 패칭하되, 기존에 `Link` 있는 부분을 컴포넌트로 분리하였습니다. `link`의 `href`에는 동적으로 할당되는 값을 넣지 못하게 되어있더라구요. 즉 비동기로 불러오는 값을 바로 `href`에 못넣어주기 때문에, 이를 컴포넌트로 분리하고 `prop`으로 받도록 했습니다.
