### PR TITLE
[ Refactor ] 페이지네이션 깜빡임 해결

### DIFF
--- a/src/api/groups/ranking.ts
+++ b/src/api/groups/ranking.ts
@@ -1,10 +1,16 @@
 import { kyInstance } from "@/api";
 import type { RankingResponse } from "@/api/groups/type";
 
-export const getAllRanking = async (groupId: number) => {
+export const getTopRanking = async (groupId: number) => {
   const response = await kyInstance
     .get<RankingResponse>(`api/groups/${groupId}/rankings`)
     .json();
 
-  return response;
+  return response.content.slice(0, 3);
 };
+
+export const getAllRanking = async (groupId: number, page: number) => {
+  const response = await kyInstance.get<RankingResponse>(`api/groups/${groupId}/rankings?page=${page}&size=4`).json();
+
+  return response;
+}

--- a/src/api/groups/ranking.ts
+++ b/src/api/groups/ranking.ts
@@ -10,7 +10,9 @@ export const getTopRanking = async (groupId: number) => {
 };
 
 export const getAllRanking = async (groupId: number, page: number) => {
-  const response = await kyInstance.get<RankingResponse>(`api/groups/${groupId}/rankings?page=${page}&size=4`).json();
+  const response = await kyInstance
+    .get<RankingResponse>(`api/groups/${groupId}/rankings?page=${page}&size=4`)
+    .json();
 
   return response;
-}
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,7 +12,7 @@ export const kyInstance = ky.create({
   headers: {
     "Content-Type": "application/json",
     Authorization:
-      "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE3MzI4MDI1NDR9.5oI0_Ja7nSxuFgor5WwDDoKOt2-MEMvGp63M7YRD2gs",
+      "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE3MzM0NjY4NDh9.lDvrqFN5KH8gj7G_ZvmP6uX1N5JKChZA-ZH8LP1DmT0",
   },
 });
 
@@ -20,6 +20,6 @@ export const kyFileInstance = ky.create({
   prefixUrl: process.env.NEXT_PUBLIC_HOST,
   headers: {
     Authorization:
-      "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE3MzI4MDI1NDR9.5oI0_Ja7nSxuFgor5WwDDoKOt2-MEMvGp63M7YRD2gs",
+      "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE3MzM0NjY4NDh9.lDvrqFN5KH8gj7G_ZvmP6uX1N5JKChZA-ZH8LP1DmT0",
   },
 });

--- a/src/app/[user]/my-solved/page.tsx
+++ b/src/app/[user]/my-solved/page.tsx
@@ -1,43 +1,59 @@
 "use client";
 
-import {
-  useExpiredMySolutionsQuery,
-  useInProgressMySolutionsQuery,
-} from "@/app/[user]/my-solved/query";
+import { getExpiredMySolutions, getInProgressMySolutions } from "@/api/users";
 import Sidebar from "@/common/component/Sidebar";
+import { usePaginationQuery } from "@/shared/hook/usePaginationQuery";
 import { sidebarWrapper } from "@/styles/shared.css";
 import MySolvedSection from "@/view/group/my-solved/Section";
-import { useState } from "react";
 
 const MySolvedPage = () => {
-  const [inProgressPage, setInProgressPage] = useState(1);
-  const [expiredPage, setExpiredPage] = useState(1);
+  const {
+    data: inProgressData,
+    currentPage: inProgressPage,
+    totalPages: inProgressTotalPages,
+    setCurrentPage: setInProgressPage,
+  } = usePaginationQuery({
+    queryKey: ["inProgressMySolutions"],
+    queryFn: (page: number) =>
+      getInProgressMySolutions({
+        page,
+        size: 3,
+      }),
+  });
+  const inProgressList = inProgressData?.content || [];
 
-  const { content: inProgressData, totalPages: inProgressTotalPages } =
-    useInProgressMySolutionsQuery({ page: inProgressPage - 1 });
-  const { content: expiredData, totalPages: expiredTotalPages } =
-    useExpiredMySolutionsQuery({ page: expiredPage - 1 });
-
-  const handleInProgressPageChange = (page: number) => setInProgressPage(page);
-  const handleExpiredPageChange = (page: number) => setExpiredPage(page);
+  const {
+    data: expiredData,
+    currentPage: expiredPage,
+    totalPages: expiredTotalPages,
+    setCurrentPage: setExpiredPage,
+  } = usePaginationQuery({
+    queryKey: ["expiredMySolutions"],
+    queryFn: (page: number) =>
+      getExpiredMySolutions({
+        page,
+        size: 3,
+      }),
+  });
+  const expiredList = expiredData?.content || [];
 
   return (
     <main className={sidebarWrapper}>
       <Sidebar />
       <section style={{ width: "80%", marginTop: "4.8rem" }}>
         <MySolvedSection
-          data={inProgressData}
+          data={inProgressList}
           title="진행중인 문제"
           totalPages={inProgressTotalPages}
           currentPage={inProgressPage}
-          onPageChange={handleInProgressPageChange}
+          onPageChange={setInProgressPage}
         />
         <MySolvedSection
-          data={expiredData}
+          data={expiredList}
           title="만료된 문제"
           totalPages={expiredTotalPages}
           currentPage={expiredPage}
-          onPageChange={handleExpiredPageChange}
+          onPageChange={setExpiredPage}
         />
       </section>
     </main>

--- a/src/app/group/[groupId]/my-solved/page.tsx
+++ b/src/app/group/[groupId]/my-solved/page.tsx
@@ -1,43 +1,67 @@
 "use client";
 
 import {
-  useExpiredMySolutionsQuery,
-  useInProgressMySolutionsQuery,
-} from "@/app/[user]/my-solved/query";
+  getExpiredMyGroupSolutions,
+  getInProgressMyGroupSolutions,
+} from "@/api/solutions";
+import {} from "@/app/[user]/my-solved/query";
 import Sidebar from "@/common/component/Sidebar";
+import { usePaginationQuery } from "@/shared/hook/usePaginationQuery";
 import { sidebarWrapper } from "@/styles/shared.css";
 import MySolvedSection from "@/view/group/my-solved/Section";
-import { useState } from "react";
 
-const MyGroupSolvedPage = () => {
-  const [inProgressPage, setInProgressPage] = useState(1);
-  const [expiredPage, setExpiredPage] = useState(1);
+const MyGroupSolvedPage = ({
+  params: { groupId },
+}: { params: { groupId: string } }) => {
+  const {
+    data: inProgressData,
+    currentPage: inProgressPage,
+    totalPages: inProgressTotalPages,
+    setCurrentPage: setInProgressPage,
+  } = usePaginationQuery({
+    queryKey: ["inProgressMyGroupSolutions", +groupId],
+    queryFn: (page: number) =>
+      getInProgressMyGroupSolutions({
+        groupId: +groupId,
+        page,
+        size: 3,
+      }),
+  });
+  const inProgressList = inProgressData?.content || [];
 
-  const { content: inProgressData, totalPages: inProgressTotalPages } =
-    useInProgressMySolutionsQuery({ page: inProgressPage - 1 });
-  const { content: expiredData, totalPages: expiredTotalPages } =
-    useExpiredMySolutionsQuery({ page: expiredPage - 1 });
-
-  const handleInProgressPageChange = (page: number) => setInProgressPage(page);
-  const handleExpiredPageChange = (page: number) => setExpiredPage(page);
+  const {
+    data: expiredData,
+    currentPage: expiredPage,
+    totalPages: expiredTotalPages,
+    setCurrentPage: setExpiredPage,
+  } = usePaginationQuery({
+    queryKey: ["expiredMyGroupSolutions", +groupId],
+    queryFn: (page: number) =>
+      getExpiredMyGroupSolutions({
+        groupId: +groupId,
+        page,
+        size: 3,
+      }),
+  });
+  const expiredList = expiredData?.content || [];
 
   return (
     <main className={sidebarWrapper}>
       <Sidebar />
       <section style={{ width: "80%", marginTop: "4.8rem" }}>
         <MySolvedSection
-          data={inProgressData}
+          data={inProgressList}
           title="진행중인 문제"
           totalPages={inProgressTotalPages}
           currentPage={inProgressPage}
-          onPageChange={handleInProgressPageChange}
+          onPageChange={setInProgressPage}
         />
         <MySolvedSection
-          data={expiredData}
+          data={expiredList}
           title="만료된 문제"
           totalPages={expiredTotalPages}
           currentPage={expiredPage}
-          onPageChange={handleExpiredPageChange}
+          onPageChange={setExpiredPage}
         />
       </section>
     </main>

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,5 +1,5 @@
 import { getGroupInfo, getGroupMemberList } from "@/api/groups";
-import { getAllRanking } from "@/api/groups/ranking";
+import { getTopRanking } from "@/api/groups/ranking";
 import { getDeadlineReachedProblems } from "@/api/problems";
 import { listSectionStyle, titleStyle } from "@/app/group/[groupId]/page.css";
 import Sidebar from "@/common/component/Sidebar";
@@ -13,7 +13,7 @@ const GroupDashboardPage = async ({
   params: { groupId },
 }: { params: { groupId: string } }) => {
   const groupInfoData = getGroupInfo(+groupId);
-  const rankingData = getAllRanking(+groupId);
+  const rankingData = getTopRanking(+groupId);
   const memberData = getGroupMemberList(+groupId);
   const deadlineReachedData = getDeadlineReachedProblems(+groupId);
 
@@ -32,7 +32,7 @@ const GroupDashboardPage = async ({
       </Sidebar>
       <div className={listSectionStyle}>
         <NoticeBanner />
-        <Ranking rankingData={rankingInfo.content} />
+        <Ranking rankingData={rankingInfo} />
         <h2 className={titleStyle}>풀어야 할 문제</h2>
         <section>
           <ProblemList.Header />

--- a/src/app/group/[groupId]/problem-list/page.tsx
+++ b/src/app/group/[groupId]/problem-list/page.tsx
@@ -1,19 +1,16 @@
 "use client";
 
-import {
-  useExpiredProblemQuery,
-  useInProgressProblemQuery,
-} from "@/app/group/[groupId]/problem-list/query";
+import { getInProgressProblems } from "@/api/problems";
 import { useGroupRoleQuery } from "@/app/group/[groupId]/query";
 import Sidebar from "@/common/component/Sidebar";
 import TabGroup from "@/common/component/Tab";
+import { usePaginationQuery } from "@/shared/hook/usePaginationQuery";
 import { sidebarWrapper } from "@/styles/shared.css";
 import ProgressList from "@/view/group/problem-list";
 import PendingList from "@/view/group/problem-list/PendingList";
 import PendingListHeader from "@/view/group/problem-list/PendingListHeader";
 import ProblemSidebar from "@/view/group/problem-list/ProblemSidebar";
 import { pageStyle, titleStyle } from "@/view/group/problem-list/index.css";
-import { useState } from "react";
 
 const ProblemListPage = ({
   params: { groupId },
@@ -21,16 +18,29 @@ const ProblemListPage = ({
   const { data: role } = useGroupRoleQuery(+groupId);
   const isOwner = role !== "PARTICIPANT";
 
-  const [inProgressPage, setInProgressPage] = useState(1);
-  const [expiredPage, setExpiredPage] = useState(1);
+  const {
+    data: inProgressData,
+    currentPage: inProgressPage,
+    totalPages: inProgressTotalPages,
+    setCurrentPage: setInProgressPage,
+  } = usePaginationQuery({
+    queryKey: ["inProgressProblem", groupId],
+    queryFn: (page) =>
+      getInProgressProblems({ groupId: +groupId, page, size: 3 }),
+  });
+  const inProgressList = inProgressData?.content;
 
-  const { content: inProgressData, totalPages: inProgressTotalPages } =
-    useInProgressProblemQuery(+groupId, inProgressPage - 1);
-  const { content: expiredData, totalPages: expiredTotalPages } =
-    useExpiredProblemQuery(+groupId, expiredPage - 1);
-
-  const handleInProgressPageChange = (page: number) => setInProgressPage(page);
-  const handleExpiredPageChange = (page: number) => setExpiredPage(page);
+  const {
+    data: expiredData,
+    currentPage: expiredPage,
+    totalPages: expiredTotalPages,
+    setCurrentPage: setExpiredPage,
+  } = usePaginationQuery({
+    queryKey: ["inProgressProblem", groupId],
+    queryFn: (page) =>
+      getInProgressProblems({ groupId: +groupId, page, size: 3 }),
+  });
+  const expiredList = expiredData?.content;
 
   return (
     <main className={sidebarWrapper}>
@@ -50,25 +60,25 @@ const ProblemListPage = ({
               <section>
                 <div style={{ width: "100%", margin: "1.6rem 0" }}>
                   <h2 className={titleStyle}>진행중인 문제</h2>
-                  {inProgressData.length && (
+                  {inProgressList?.length && (
                     <ProgressList
-                      data={inProgressData}
+                      data={inProgressList}
                       totalPages={inProgressTotalPages}
                       currentPage={inProgressPage}
-                      onPageChange={handleInProgressPageChange}
                       isOwner={isOwner}
+                      onPageChange={setInProgressPage}
                     />
                   )}
                 </div>
                 <div style={{ width: "100%", margin: "1.6rem 0" }}>
                   <h2 className={titleStyle}>만료된 문제</h2>
-                  {expiredData.length && (
+                  {expiredList?.length && (
                     <ProgressList
-                      data={expiredData}
+                      data={expiredList}
                       totalPages={expiredTotalPages}
                       currentPage={expiredPage}
-                      onPageChange={handleExpiredPageChange}
                       isOwner={false}
+                      onPageChange={setExpiredPage}
                     />
                   )}
                 </div>
@@ -86,25 +96,25 @@ const ProblemListPage = ({
           <section>
             <div style={{ width: "100%", margin: "1.6rem 0" }}>
               <h2 className={titleStyle}>진행중인 문제</h2>
-              {inProgressData.length && (
+              {inProgressList?.length && (
                 <ProgressList
-                  data={inProgressData}
+                  data={inProgressList}
                   totalPages={inProgressTotalPages}
                   currentPage={inProgressPage}
-                  onPageChange={handleInProgressPageChange}
                   isOwner={isOwner}
+                  onPageChange={setInProgressPage}
                 />
               )}
             </div>
             <div style={{ width: "100%", margin: "1.6rem 0" }}>
               <h2 className={titleStyle}>만료된 문제</h2>
-              {expiredData.length && (
+              {expiredList?.length && (
                 <ProgressList
-                  data={expiredData}
+                  data={expiredList}
                   totalPages={expiredTotalPages}
                   currentPage={expiredPage}
-                  onPageChange={handleExpiredPageChange}
                   isOwner={false}
+                  onPageChange={setExpiredPage}
                 />
               )}
             </div>

--- a/src/app/group/[groupId]/problem-list/page.tsx
+++ b/src/app/group/[groupId]/problem-list/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getInProgressProblems } from "@/api/problems";
+import { getExpiredProblems, getInProgressProblems } from "@/api/problems";
 import { useGroupRoleQuery } from "@/app/group/[groupId]/query";
 import Sidebar from "@/common/component/Sidebar";
 import TabGroup from "@/common/component/Tab";
@@ -36,9 +36,8 @@ const ProblemListPage = ({
     totalPages: expiredTotalPages,
     setCurrentPage: setExpiredPage,
   } = usePaginationQuery({
-    queryKey: ["inProgressProblem", groupId],
-    queryFn: (page) =>
-      getInProgressProblems({ groupId: +groupId, page, size: 3 }),
+    queryKey: ["expiredProblem", groupId],
+    queryFn: (page) => getExpiredProblems({ groupId: +groupId, page, size: 3 }),
   });
   const expiredList = expiredData?.content;
 

--- a/src/shared/hook/usePaginationQuery.ts
+++ b/src/shared/hook/usePaginationQuery.ts
@@ -1,34 +1,39 @@
+import type { PaginationResponse } from "@/api/type";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
 type UsePaginationQueryProps<T> = {
-  queryKey: (string| number)[];
+  queryKey: (string | number)[];
   queryFn: (page: number) => Promise<T>;
   initialPage?: number;
-}
+};
 
-export const usePaginationQuery = <T> ({queryKey, queryFn, initialPage = 1}: UsePaginationQueryProps<T>) => {
+export const usePaginationQuery = <T>({
+  queryKey,
+  queryFn,
+  initialPage = 1,
+}: UsePaginationQueryProps<T>) => {
   const [currentPage, setCurrentPage] = useState(initialPage);
   const [totalPages, setTotalPages] = useState<number>(0);
-  const [data, setData] = useState<T|null>(null);
-  console.log({totalPages})
+  const [data, setData] = useState<T | null>(null);
+
   const queryClient = useQueryClient();
 
   const fetchData = async () => {
     const result = await queryFn(currentPage - 1);
     setData(result);
-    setTotalPages((result as any)?.totalPages || 0);
-  }
+    setTotalPages((result as PaginationResponse).totalPages || 0);
+  };
 
   useEffect(() => {
     fetchData();
     if (currentPage < totalPages) {
-      queryClient.prefetchQuery(
-        {queryKey: [...queryKey, currentPage],
-        queryFn: () => queryFn(currentPage)}
-      );
+      queryClient.prefetchQuery({
+        queryKey: [...queryKey, currentPage],
+        queryFn: () => queryFn(currentPage),
+      });
     }
   }, [currentPage, queryFn, queryKey, queryClient, totalPages]);
 
-  return {data, currentPage, setCurrentPage, totalPages};
-}
+  return { data, currentPage, setCurrentPage, totalPages };
+};

--- a/src/shared/hook/usePaginationQuery.ts
+++ b/src/shared/hook/usePaginationQuery.ts
@@ -1,0 +1,34 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+type UsePaginationQueryProps<T> = {
+  queryKey: (string| number)[];
+  queryFn: (page: number) => Promise<T>;
+  initialPage?: number;
+}
+
+export const usePaginationQuery = <T> ({queryKey, queryFn, initialPage = 1}: UsePaginationQueryProps<T>) => {
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [data, setData] = useState<T|null>(null);
+  
+  const queryClient = useQueryClient();
+
+  const fetchData = async () => {
+    const result = await queryFn(currentPage - 1);
+    setData(result);
+    setTotalPages((result as any)?.totalPages || 0);
+  }
+
+  useEffect(() => {
+    fetchData();
+    if (currentPage < totalPages) {
+      queryClient.prefetchQuery(
+        {queryKey: [...queryKey, currentPage],
+        queryFn: () => queryFn(currentPage)}
+      );
+    }
+  }, [currentPage, queryFn, queryKey, queryClient, totalPages]);
+
+  return {data, currentPage, setCurrentPage, totalPages};
+}

--- a/src/shared/hook/usePaginationQuery.ts
+++ b/src/shared/hook/usePaginationQuery.ts
@@ -11,7 +11,7 @@ export const usePaginationQuery = <T> ({queryKey, queryFn, initialPage = 1}: Use
   const [currentPage, setCurrentPage] = useState(initialPage);
   const [totalPages, setTotalPages] = useState<number>(0);
   const [data, setData] = useState<T|null>(null);
-  
+  console.log({totalPages})
   const queryClient = useQueryClient();
 
   const fetchData = async () => {

--- a/src/shared/hook/usePaginationQuery.ts
+++ b/src/shared/hook/usePaginationQuery.ts
@@ -1,6 +1,6 @@
 import type { PaginationResponse } from "@/api/type";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 type UsePaginationQueryProps<T> = {
   queryKey: (string | number)[];
@@ -19,22 +19,21 @@ export const usePaginationQuery = <T>({
 
   const queryClient = useQueryClient();
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     const result = await queryFn(currentPage - 1);
     setData(result);
     setTotalPages((result as PaginationResponse).totalPages || 0);
-  };
+  }, [currentPage]);
 
   useEffect(() => {
     fetchData();
-  }, [currentPage, queryFn, queryKey, queryClient, totalPages]);
-
-  if (currentPage < totalPages) {
-    queryClient.prefetchQuery({
-      queryKey: [...queryKey, currentPage],
-      queryFn: () => queryFn(currentPage),
-    });
-  }
+    if (currentPage < totalPages) {
+      queryClient.prefetchQuery({
+        queryKey: [...queryKey, currentPage],
+        queryFn: () => queryFn(currentPage),
+      });
+    }
+  }, [currentPage, totalPages]);
 
   return { data, currentPage, setCurrentPage, totalPages };
 };

--- a/src/shared/hook/usePaginationQuery.ts
+++ b/src/shared/hook/usePaginationQuery.ts
@@ -27,13 +27,14 @@ export const usePaginationQuery = <T>({
 
   useEffect(() => {
     fetchData();
-    if (currentPage < totalPages) {
-      queryClient.prefetchQuery({
-        queryKey: [...queryKey, currentPage],
-        queryFn: () => queryFn(currentPage),
-      });
-    }
   }, [currentPage, queryFn, queryKey, queryClient, totalPages]);
+
+  if (currentPage < totalPages) {
+    queryClient.prefetchQuery({
+      queryKey: [...queryKey, currentPage],
+      queryFn: () => queryFn(currentPage),
+    });
+  }
 
   return { data, currentPage, setCurrentPage, totalPages };
 };

--- a/src/view/group/dashboard/NoticeModal/NoticeList/index.tsx
+++ b/src/view/group/dashboard/NoticeModal/NoticeList/index.tsx
@@ -1,13 +1,14 @@
 "use client";
-import { useNoticesQuery } from "@/app/group/[groupId]/notice/query";
+import { getNotices } from "@/api/notices";
 import defaultImage from "@/asset/img/img_card_profile.png";
 import { IcnNew } from "@/asset/svg";
 import Avatar from "@/common/component/Avatar";
 import Pagination from "@/shared/component/Pagination";
 import useGetGroupId from "@/shared/hook/useGetGroupId";
+import { usePaginationQuery } from "@/shared/hook/usePaginationQuery";
 import { overlayStyle, textStyle } from "@/view/group/dashboard/index.css";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import {} from "react";
 import {
   contentStyle,
   contentWrapper,
@@ -18,9 +19,6 @@ import {
   paginationStyle,
   ulStyle,
 } from "./index.css";
-import { useQueryClient } from "@tanstack/react-query";
-import { getNotices } from "@/api/notices";
-import { usePaginationQuery } from "@/shared/hook/usePaginationQuery";
 
 const NoticeList = () => {
   const router = useRouter();
@@ -29,11 +27,15 @@ const NoticeList = () => {
   const handleClick = (noticeId: number) =>
     router.push(`/group/${groupId}/notice/${noticeId}`);
 
-  const { data: noticeData, currentPage, totalPages, setCurrentPage } =
-    usePaginationQuery({
-      queryKey: ["notices", groupId],
-      queryFn: (page) => getNotices({ groupId: +groupId, page }),
-    });
+  const {
+    data: noticeData,
+    currentPage,
+    totalPages,
+    setCurrentPage,
+  } = usePaginationQuery({
+    queryKey: ["notices", groupId],
+    queryFn: (page) => getNotices({ groupId: +groupId, page }),
+  });
   const noticeList = noticeData?.content;
 
   return (

--- a/src/view/group/dashboard/NoticeModal/NoticeList/index.tsx
+++ b/src/view/group/dashboard/NoticeModal/NoticeList/index.tsx
@@ -7,7 +7,7 @@ import Pagination from "@/shared/component/Pagination";
 import useGetGroupId from "@/shared/hook/useGetGroupId";
 import { overlayStyle, textStyle } from "@/view/group/dashboard/index.css";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   contentStyle,
   contentWrapper,
@@ -18,18 +18,23 @@ import {
   paginationStyle,
   ulStyle,
 } from "./index.css";
+import { useQueryClient } from "@tanstack/react-query";
+import { getNotices } from "@/api/notices";
+import { usePaginationQuery } from "@/shared/hook/usePaginationQuery";
 
 const NoticeList = () => {
-  const [currentPage, setCurrentPage] = useState(1);
   const router = useRouter();
   const groupId = useGetGroupId();
-  const { content: noticeList, totalPages } = useNoticesQuery({
-    groupId: +groupId,
-    page: currentPage - 1,
-  });
 
   const handleClick = (noticeId: number) =>
     router.push(`/group/${groupId}/notice/${noticeId}`);
+
+  const { data: noticeData, currentPage, totalPages, setCurrentPage } =
+    usePaginationQuery({
+      queryKey: ["notices", groupId],
+      queryFn: (page) => getNotices({ groupId: +groupId, page }),
+    });
+  const noticeList = noticeData?.content;
 
   return (
     <>

--- a/src/view/group/dashboard/Ranking/AllRanking.tsx
+++ b/src/view/group/dashboard/Ranking/AllRanking.tsx
@@ -10,11 +10,15 @@ import { allRankingWrapper } from "@/view/group/dashboard/Ranking/index.css";
 const AllRanking = () => {
   const groupId = useGetGroupId();
 
-  const { data: allRankingData, currentPage, totalPages, setCurrentPage } =
-    usePaginationQuery({
-      queryKey: ["ranking", +groupId],
-      queryFn: (page) => getAllRanking(+groupId, page),
-    });
+  const {
+    data: allRankingData,
+    currentPage,
+    totalPages,
+    setCurrentPage,
+  } = usePaginationQuery({
+    queryKey: ["ranking", +groupId],
+    queryFn: (page) => getAllRanking(+groupId, page),
+  });
   const allRankingList = allRankingData?.content;
 
   return (

--- a/src/view/group/dashboard/Ranking/AllRanking.tsx
+++ b/src/view/group/dashboard/Ranking/AllRanking.tsx
@@ -1,29 +1,34 @@
 "use client";
-import type { RankingContent } from "@/api/groups/type";
+
+import { getAllRanking } from "@/api/groups/ranking";
 import Pagination from "@/shared/component/Pagination";
+import useGetGroupId from "@/shared/hook/useGetGroupId";
+import { usePaginationQuery } from "@/shared/hook/usePaginationQuery";
 import RankList from "@/view/group/dashboard/Ranking/RankList";
 import { allRankingWrapper } from "@/view/group/dashboard/Ranking/index.css";
-import { useState } from "react";
 
-const AllRanking = ({
-  allRankingData,
-}: { allRankingData: RankingContent[] }) => {
-  const [page, setPage] = useState(1);
+const AllRanking = () => {
+  const groupId = useGetGroupId();
+
+  const { data: allRankingData, currentPage, totalPages, setCurrentPage } =
+    usePaginationQuery({
+      queryKey: ["ranking", +groupId],
+      queryFn: (page) => getAllRanking(+groupId, page),
+    });
+  const allRankingList = allRankingData?.content;
 
   return (
     <>
       <ol className={allRankingWrapper}>
-        {allRankingData.map((data, idx) => (
+        {allRankingList?.map((data, idx) => (
           <RankList key={idx} info={data} />
         ))}
       </ol>
-      {allRankingData.length > 0 && (
-        <Pagination
-          totalPages={allRankingData.length / 4}
-          currentPage={page}
-          onPageChange={setPage}
-        />
-      )}
+      <Pagination
+        totalPages={totalPages}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
     </>
   );
 };

--- a/src/view/group/dashboard/Ranking/index.tsx
+++ b/src/view/group/dashboard/Ranking/index.tsx
@@ -19,12 +19,12 @@ const Ranking = ({ rankingData }: { rankingData: RankingContent[] }) => {
       </TabGroup.TabList>
       <TabGroup.TabPanels>
         {isValid ? (
-          <TopRanking topRankingData={rankingData.slice(0, 3)} />
+          <TopRanking topRankingData={rankingData} />
         ) : (
           <EmptyRanking />
         )}
         {isValid ? (
-          <AllRanking allRankingData={rankingData} />
+          <AllRanking />
         ) : (
           <EmptyRanking />
         )}

--- a/src/view/group/dashboard/Ranking/index.tsx
+++ b/src/view/group/dashboard/Ranking/index.tsx
@@ -23,11 +23,7 @@ const Ranking = ({ rankingData }: { rankingData: RankingContent[] }) => {
         ) : (
           <EmptyRanking />
         )}
-        {isValid ? (
-          <AllRanking />
-        ) : (
-          <EmptyRanking />
-        )}
+        {isValid ? <AllRanking /> : <EmptyRanking />}
       </TabGroup.TabPanels>
     </TabGroup.Tabs>
   );

--- a/src/view/group/my-solved/Section/index.tsx
+++ b/src/view/group/my-solved/Section/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/view/group/my-solved/Section/index.css";
 import SolvedItem from "@/view/group/my-solved/SolvedItem";
 
-type MySolvedSection = {
+type MySolvedSectionProps = {
   title: string;
   data: SolutionContent[];
   totalPages: number;
@@ -24,7 +24,7 @@ const MySolvedSection = ({
   totalPages,
   currentPage,
   onPageChange,
-}: MySolvedSection) => {
+}: MySolvedSectionProps) => {
   return (
     <div className={sectionStyle}>
       <h2 className={titleStyle}>{title}</h2>

--- a/src/view/group/problem-list/PendingList/index.tsx
+++ b/src/view/group/problem-list/PendingList/index.tsx
@@ -1,19 +1,25 @@
-import { useQueuedProblemQuery } from "@/app/group/[groupId]/problem-list/query";
+import { getQueuedProblems } from "@/api/problems";
 import Pagination from "@/shared/component/Pagination";
+import { usePaginationQuery } from "@/shared/hook/usePaginationQuery";
 import PendingListItem from "@/view/group/problem-list/PendingList/Item";
 import { listStyle } from "@/view/group/problem-list/PendingList/index.css";
-import { useState } from "react";
 
 const PendingList = ({ groupId }: { groupId: number }) => {
-  const [queuedPage, setQueuedPage] = useState(1);
-  const { content: queuedData, totalPages: queuedTotalPages } =
-    useQueuedProblemQuery(+groupId, queuedPage - 1);
-  const handleQueuedPageChange = (page: number) => setQueuedPage(page);
+  const {
+    data: queuedData,
+    currentPage: queuedPage,
+    totalPages: queuedTotalPages,
+    setCurrentPage: setQueuedPage,
+  } = usePaginationQuery({
+    queryKey: ["queuedProblem", groupId],
+    queryFn: (page) => getQueuedProblems({ groupId, page, size: 7 }),
+  });
+  const queuedList = queuedData?.content;
 
   return (
     <>
       <ul className={listStyle}>
-        {queuedData.map((item) => (
+        {queuedList?.map((item) => (
           <PendingListItem
             key={item.problemId}
             problemId={item.problemId}
@@ -23,12 +29,12 @@ const PendingList = ({ groupId }: { groupId: number }) => {
           />
         ))}
       </ul>
-      {queuedData.length && (
+      {queuedList?.length && (
         <Pagination
           style={{ marginTop: "1.6rem" }}
           totalPages={queuedTotalPages}
           currentPage={queuedPage}
-          onPageChange={handleQueuedPageChange}
+          onPageChange={setQueuedPage}
         />
       )}
     </>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #236 

## ✅ Done Task
  - [x] 랭킹 페이지네이션 연결
  - [x] 페이지네이션 prefetch 훅 구현

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

### 데이터 prefetching

- 현재페이지 상태가 변경될 때 다음 페이지를 prefetch
- `useEffect` 훅 사용해서 `currentPage` 변경될 때 `queryClient` 의 `prefetchQuery` 메소드 사용
    
    ```ts
    const NoticeList = () => {
      const [currentPage, setCurrentPage] = useState(1);
      const router = useRouter();
      const groupId = useGetGroupId();
      const { content: noticeList, totalPages } = useNoticesQuery({
        groupId: +groupId,
        page: currentPage - 1,
      });
    
      const handleClick = (noticeId: number) =>
        router.push(`/group/${groupId}/notice/${noticeId}`);
    
      const queryClient = useQueryClient();
    
      useEffect(() => {
        if (currentPage < totalPages) {
          queryClient.prefetchQuery({
            queryKey: ["notices", +groupId, currentPage],
            queryFn: () => getNotices({ groupId: +groupId, page: currentPage }),
          })
        }
      }, [currentPage]);
    
    ```
- 이를 모든 페이지네이션에서 일괄적으로 사용할 수 있도록 hook 으로 분리하였습니다.

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

- 페이지네이션 훅 적용하는 부분은 일괄적으로 진행하기 위해 공지, 랭킹 부분에만 임시적으로 반영해두었습니다. 코드리뷰 받고 반영되는 대로 다른 페이지네이션에도 적용할 예정입니다.
- 스크린샷에 `totalPages` 첫번째가 이상한 것은 서버이슈입니다. 서버 부분 고쳐지면 자동으로 반영될 예정이에요!

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

- Before

https://github.com/user-attachments/assets/8ce6ac84-4c19-4dc6-9e3e-8966dbbde366

- After

https://github.com/user-attachments/assets/6280dcda-de21-4b92-a084-e81f73cc1195

