### PR TITLE
[ Fix ] 필터링 오류 수정

### DIFF
--- a/src/app/[user]/setting/query.ts
+++ b/src/app/[user]/setting/query.ts
@@ -37,13 +37,14 @@ const transformData = (
   }));
 };
 
-export const useVisibilityMutation = (groupId: number) => {
+export const useVisibilityMutation = () => {
   const queryClient = useQueryClient();
 
   const { showToast } = useToast();
 
   return useMutation({
-    mutationFn: (flag: boolean) => patchGroupVisibility(groupId, flag),
+    mutationFn: ({ groupId, flag }: { groupId: number; flag: boolean }) =>
+      patchGroupVisibility(groupId, flag),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["groups", "setting"],

--- a/src/view/user/setting/StudyList/StudyListTable/StudyListProvider.tsx
+++ b/src/view/user/setting/StudyList/StudyListTable/StudyListProvider.tsx
@@ -1,3 +1,6 @@
+import { useVisibilityMutation } from "@/app/[user]/setting/query";
+import type { UseMutateFunction } from "@tanstack/react-query";
+import type { HTTPError, KyResponse } from "ky";
 import type React from "react";
 import { createContext, useReducer } from "react";
 import type { StudyListType } from "./type";
@@ -5,7 +8,20 @@ import type { StudyListType } from "./type";
 type TableDataContextType =
   | { processedData: StudyListType[]; state: State }
   | undefined;
-type TableDispatchContextType = React.Dispatch<Actions> | undefined;
+type TableDispatchContextType =
+  | {
+      dispatch: React.Dispatch<Actions>;
+      mutation: UseMutateFunction<
+        KyResponse<unknown>,
+        HTTPError<unknown>,
+        {
+          groupId: number;
+          flag: boolean;
+        },
+        unknown
+      >;
+    }
+  | undefined;
 
 export const TableDataContext = createContext<TableDataContextType>(undefined);
 export const TableDispatchContext =
@@ -106,6 +122,7 @@ export const StudyListTableProvider = ({
     filterKey: undefined,
     filterValue: "",
   } as State);
+  const { mutate: visibilityMutate } = useVisibilityMutation();
 
   // 데이터 전처리 (정렬, 필터링)
   const processedData = data
@@ -137,7 +154,9 @@ export const StudyListTableProvider = ({
     });
 
   return (
-    <TableDispatchContext.Provider value={dispatch}>
+    <TableDispatchContext.Provider
+      value={{ dispatch, mutation: visibilityMutate }}
+    >
       <TableDataContext.Provider value={{ state, processedData }}>
         {children}
       </TableDataContext.Provider>

--- a/src/view/user/setting/StudyList/StudyListTable/constant.tsx
+++ b/src/view/user/setting/StudyList/StudyListTable/constant.tsx
@@ -1,4 +1,3 @@
-import { useVisibilityMutation } from "@/app/[user]/setting/query";
 import { IcnBtnPin, IcnCalendarTable } from "@/asset/svg";
 import {
   tableCellTextStyle,
@@ -12,7 +11,11 @@ import SortIcon from "../SortIcon";
 import StatusDropdownMenu from "../StatusDropdownMenu";
 import { textStyle } from "../StatusDropdownMenu/index.css";
 import StatusIcon from "../StatusIcon";
-import { useStudyListDispatch, useStudyListState } from "./hook";
+import {
+  useStudyListDispatch,
+  useStudyListMutation,
+  useStudyListState,
+} from "./hook";
 import type { StudyListType } from "./type";
 
 export const STUDY_LIST_COLUMNS: TableDataType<StudyListType>[] = [
@@ -103,11 +106,12 @@ export const STUDY_LIST_COLUMNS: TableDataType<StudyListType>[] = [
     key: "isPublic",
     Header: () => "공개여부",
     Cell: (data) => {
-      const { mutate: visibilityMutate } = useVisibilityMutation(data.id);
-
+      const visibilityMutate = useStudyListMutation();
       return (
         <button
-          onClick={() => visibilityMutate(!data.isVisible)}
+          onClick={() =>
+            visibilityMutate({ groupId: data.id, flag: !data.isVisible })
+          }
           className={visibilityBtnStyle}
         >
           {data.isVisible ? "ON" : "OFF"}

--- a/src/view/user/setting/StudyList/StudyListTable/hook.ts
+++ b/src/view/user/setting/StudyList/StudyListTable/hook.ts
@@ -22,5 +22,13 @@ export const useStudyListDispatch = () => {
   if (!context) {
     throw new Error("useStudyListDispatch must be used within a TableProvider");
   }
-  return context;
+  return context.dispatch;
+};
+
+export const useStudyListMutation = () => {
+  const context = useContext(TableDispatchContext);
+  if (!context) {
+    throw new Error("useStudyListMutation must be used within a TableProvider");
+  }
+  return context.mutation;
 };


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #245 

## ✅ Done Task
  - [x] 공개 여부 Cell 컴포넌트에 사용된 mutation 함수를 context api로 받아오게 변경

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
필터링을 하며 컴포넌트 수가 변경되면서 공개 여부 Cell 컴포넌트에 사용된 `useVisibilityMutation` 훅을 호출하는 횟수가 달라지게 됩니다. 이것이 문제가 되어 에러가 발생했던 것인데, `useVisibilityMutation`에는 `showToast`와 `useMutation` 훅을 사용하고 있으며 이 두 함수는 `setState`를 내부에서 사용하고 있습니다(`setAtom` 등). 필터링 기능을 수행 후 이 `setState`의 호출 횟수가 달라지게 되면 더 이상 순수 함수가 아니게 되어 리액트에서 자체적으로 에러를 내고 렌더링을 멈추는 것이죠.

실제로 테스트를 해보면 필터링 하여 수를 줄였을 때는 warning으로 "이전 렌더링보다 적은 수의 훅이 호출됐다,"고 나오며, 수를 늘렸을 때는 "이전 렌더링보다 많은 수의 훅이 호출됐다" 라고 나옵니다.

이를 해결하기 위해 `useVisibilityMutation`을 `context api`로 이동시켜 `useContext`로 불러와 사용하도록 변경하여 모든 행이 같은 `useVisibilityMutation`을 사용하도록 변경했습니다.
그에 따라 필터링으로 수가 변경돼도 `useVisibilityMutation`는 한 번만 호출되어 문제가 해결됩니다.

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->