### PR TITLE
[ Fix ] nextAuth 배포 에러 해결

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,6 +7,7 @@ import type { AdapterUser } from "../next-auth";
 
 // 컴포넌트에서 auth()를 통해 불러와 사용할 session 데이터를 수정할 수 있음
 export const { auth, handlers, signIn, signOut } = NextAuth({
+  trustHost: true,
   pages: {
     signIn: "/login",
     error: "/error",


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #264 

## ✅ Done Task
  - [x] nextAuth 배포 에러 해결

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

- 아래와 같은 에러가 발생했다.
  ```shell
  next auth scp file to server. 2024/12/19 13:53:25 error copy file to dest: ***, error message: dial tcp 3.39.***5.63:***: i/o timeout drone-scp error: error copy file to dest: ***, error message: dial tcp 3.39.***5.63:***: i/o timeout
  ```

  - 신뢰되지 않은 호스트라 발생하는 에러라고 한다.
  - 방법 1: `AUTH_TRUST_HOST=http://localhost:3000` 환경변수 추가하기
  - 방법 2: NextAuth 옵션에서 `trustHost: true` 옵션 추가하기
  - 위 두가지 방법 중 방법 2를 택하여 해결하였다.
