### PR TITLE
[ Fix ] 코멘트 뷰 유저에 따른 UI 미반영 사항들 적용

### DIFF
--- a/src/shared/component/CommentBox/index.tsx
+++ b/src/shared/component/CommentBox/index.tsx
@@ -22,6 +22,7 @@ import clsx from "clsx";
 
 type CommentBox = CommentContent & {
   variant: "detail" | "notice";
+  isMine?: boolean;
   onDelete?: (commentId: number) => void;
   className?: string;
 };
@@ -33,6 +34,7 @@ const CommentBox = ({
   writerProfileImage,
   content,
   createdAt,
+  isMine,
   onDelete,
   className,
 }: CommentBox) => {
@@ -85,7 +87,10 @@ const CommentBox = ({
       <div className={iconContainerStyle}>
         <button
           onClick={handleEditBtnClick}
-          className={iconStyle({ variant: "edit", isActive })}
+          className={iconStyle({
+            variant: "edit",
+            isActive: isActive && isMine,
+          })}
         >
           <IcnEdit width={18} height={18} />
         </button>
@@ -96,7 +101,10 @@ const CommentBox = ({
           onKeyDown={(e) => {
             if (e.key === "Enter") onDelete?.(commentId);
           }}
-          className={iconStyle({ variant: "close", isActive })}
+          className={iconStyle({
+            variant: "close",
+            isActive: isActive && isMine,
+          })}
         >
           <IcnClose width={16} height={16} />
         </div>

--- a/src/shared/component/CommentBox/index.tsx
+++ b/src/shared/component/CommentBox/index.tsx
@@ -20,11 +20,11 @@ import useA11yHoverHandler from "@/shared/hook/useA11yHandler";
 import { getFormattedcreatedAt } from "@/shared/util/time";
 import clsx from "clsx";
 
-type CommentBox = CommentContent & {
+type CommentBoxProps = CommentContent & {
   variant: "detail" | "notice";
-  isMine?: boolean;
   onDelete?: (commentId: number) => void;
   className?: string;
+  isMine?: boolean;
 };
 
 const CommentBox = ({
@@ -34,10 +34,10 @@ const CommentBox = ({
   writerProfileImage,
   content,
   createdAt,
-  isMine,
   onDelete,
   className,
-}: CommentBox) => {
+  isMine,
+}: CommentBoxProps) => {
   const { isActive, handleFocus, handleBlur, handleMouseOver, handleMouseOut } =
     useA11yHoverHandler();
 
@@ -84,31 +84,33 @@ const CommentBox = ({
         )}
       </div>
 
-      <div className={iconContainerStyle}>
-        <button
-          onClick={handleEditBtnClick}
-          className={iconStyle({
-            variant: "edit",
-            isActive: isActive && isMine,
-          })}
-        >
-          <IcnEdit width={18} height={18} />
-        </button>
-        <div
-          role="button"
-          tabIndex={0}
-          onClick={() => onDelete?.(commentId)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") onDelete?.(commentId);
-          }}
-          className={iconStyle({
-            variant: "close",
-            isActive: isActive && isMine,
-          })}
-        >
-          <IcnClose width={16} height={16} />
+      {isMine && (
+        <div className={iconContainerStyle}>
+          <button
+            onClick={handleEditBtnClick}
+            className={iconStyle({
+              variant: "edit",
+              isActive: isActive,
+            })}
+          >
+            <IcnEdit width={18} height={18} />
+          </button>
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={() => onDelete?.(commentId)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onDelete?.(commentId);
+            }}
+            className={iconStyle({
+              variant: "close",
+              isActive: isActive,
+            })}
+          >
+            <IcnClose width={16} height={16} />
+          </div>
         </div>
-      </div>
+      )}
     </li>
   );
 };

--- a/src/shared/component/Header/UserMenu.tsx
+++ b/src/shared/component/Header/UserMenu.tsx
@@ -24,7 +24,7 @@ const UserMenu = () => {
       <Menu
         label="profileMenu"
         renderTriggerButton={
-          <Profile.TriggerButton src={(user as UserResponse).profileImage} />
+          <Profile.TriggerButton src={(user as UserResponse)?.profileImage} />
         }
         renderList={<Profile />}
       />

--- a/src/view/group/solved-detail/CommentSection/index.tsx
+++ b/src/view/group/solved-detail/CommentSection/index.tsx
@@ -8,6 +8,7 @@ import {
 import CommentBox from "@/shared/component/CommentBox";
 import CommentInput from "@/shared/component/CommentInput";
 import { CommentsProvider } from "@/view/group/solved-detail/CommentSection/provider";
+import { useSession } from "next-auth/react";
 import { type FormEvent, useEffect, useRef, useState } from "react";
 import { commentInputStyle, sectionWrapper, ulStyle } from "./index.css";
 
@@ -18,6 +19,7 @@ type CommentSectionProps = {
 const CommentSection = ({ solutionId }: CommentSectionProps) => {
   const commentRef = useRef<HTMLUListElement>(null);
   const [comment, setComment] = useState("");
+  const { data } = useSession();
 
   const { mutate: commentAction } = useCommentMutataion(+solutionId);
   const { mutate: deleteMutate } = useDeleteCommentMutation(+solutionId);
@@ -49,6 +51,7 @@ const CommentSection = ({ solutionId }: CommentSectionProps) => {
                 key={item.commentId}
                 variant="detail"
                 onDelete={deleteMutate}
+                isMine={item.writerNickname === data?.user?.nickname}
                 {...item}
               />
             ))}
@@ -59,6 +62,7 @@ const CommentSection = ({ solutionId }: CommentSectionProps) => {
           name="comment"
           value={comment}
           onChange={(e) => setComment(e.target.value)}
+          profileUrl={data?.user?.profileImage}
         />
       </form>
     </div>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #269

## ✅ Done Task
  - [x] 인풋창 유저 프로필 반영
  - [x] 자신의 댓글 아닐 시 수정/추가 버튼 미표시

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

크게 중요한 것은 없었습니다.

인풋창에 유저 프로필 띄우기 위해 `useSession`을 활용하여 유저 데이터를 가져왔고, 여기서 코멘트 데이터의 `writerNickname`과 현재 유저의 닉네임을 비교하여 `isMine` 프롭을 전달해주었습니다. 그렇게 `CommentBox`에서는 해당 `prop`으로 호버 & 내댓글 일 시 수정/추가 버튼을 표시합니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->


https://github.com/user-attachments/assets/aefa529d-f65e-4cf9-b047-d8f39560d3e5

