### PR TITLE
[ Fix ] role chip layout 수정

### DIFF
--- a/src/view/group/setting/MemberList/RoleList/index.css.ts
+++ b/src/view/group/setting/MemberList/RoleList/index.css.ts
@@ -34,5 +34,7 @@ export const chipStyle = recipe({
 });
 
 export const chipWrapper = style({
-  paddingLeft: "42.5%",
+  display: "inline-flex",
+  width: "8rem",
+  paddingLeft: "0.75rem",
 });

--- a/src/view/group/setting/MemberList/RoleList/index.css.ts
+++ b/src/view/group/setting/MemberList/RoleList/index.css.ts
@@ -34,6 +34,5 @@ export const chipStyle = recipe({
 });
 
 export const chipWrapper = style({
-  display: "flex",
-  justifyContent: "center",
+  paddingLeft: "42.5%",
 });

--- a/src/view/group/setting/MemberList/RoleList/index.css.ts
+++ b/src/view/group/setting/MemberList/RoleList/index.css.ts
@@ -1,4 +1,5 @@
 import { theme } from "@/styles/themes.css";
+import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
 export const chipStyle = recipe({
@@ -30,4 +31,9 @@ export const chipStyle = recipe({
       },
     },
   },
+});
+
+export const chipWrapper = style({
+  display: "flex",
+  justifyContent: "center",
 });

--- a/src/view/group/setting/MemberList/constant.tsx
+++ b/src/view/group/setting/MemberList/constant.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/view/group/setting/MemberList/index.css";
 import SortIcon from "@/view/user/setting/GroupList/SortIcon";
 import { dropdownStyle } from "@/view/user/setting/GroupList/StatusDropdownMenu/index.css";
+import { chipWrapper } from "./RoleList/index.css";
 
 export const MEMBER_LIST_COLUMNS: TableDataType<MemberResponse>[] = [
   {
@@ -88,14 +89,13 @@ export const MEMBER_LIST_COLUMNS: TableDataType<MemberResponse>[] = [
       };
 
       return (
-        <>
+        <div className={chipWrapper}>
           <Menu
             label="role"
             renderTriggerButton={
               <div
                 style={{
                   display: "flex",
-                  justifyContent: "center",
                   width: "fit-content",
                 }}
               >
@@ -121,7 +121,7 @@ export const MEMBER_LIST_COLUMNS: TableDataType<MemberResponse>[] = [
               </Dropdown>
             }
           />
-        </>
+        </div>
       );
     },
     width: 80,

--- a/src/view/group/setting/MemberList/index.css.ts
+++ b/src/view/group/setting/MemberList/index.css.ts
@@ -31,6 +31,7 @@ export const removeBtnStyle = style({
 
 export const tableStyle = style({
   width: "100%",
+  borderCollapse: "collapse",
 });
 
 export const theadStyle = style({

--- a/src/view/user/setting/GroupList/GroupListTable/constant.tsx
+++ b/src/view/user/setting/GroupList/GroupListTable/constant.tsx
@@ -5,7 +5,10 @@ import {
 } from "@/shared/component/Table/TableElements/index.css";
 import { pinStyle } from "@/shared/component/Table/index.css";
 import type { TableDataType } from "@/shared/type/table";
-import { chipWrapper, visibilityBtnStyle } from "@/view/user/setting/GroupList/GroupListTable/index.css";
+import {
+  chipWrapper,
+  visibilityBtnStyle,
+} from "@/view/user/setting/GroupList/GroupListTable/index.css";
 import { format } from "date-fns";
 
 import type { GroupSettingsContent } from "@/app/api/groups/type";

--- a/src/view/user/setting/GroupList/GroupListTable/constant.tsx
+++ b/src/view/user/setting/GroupList/GroupListTable/constant.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/shared/component/Table/TableElements/index.css";
 import { pinStyle } from "@/shared/component/Table/index.css";
 import type { TableDataType } from "@/shared/type/table";
-import { visibilityBtnStyle } from "@/view/user/setting/GroupList/GroupListTable/index.css";
+import { chipWrapper, visibilityBtnStyle } from "@/view/user/setting/GroupList/GroupListTable/index.css";
 import { format } from "date-fns";
 
 import type { GroupSettingsContent } from "@/app/api/groups/type";
@@ -138,7 +138,7 @@ export const STUDY_LIST_COLUMNS: TableDataType<GroupSettingsContent>[] = [
     key: "status",
     Header: () => <StatusDropdownMenu />,
     Cell: (data) => (
-      <div style={{ display: "flex", justifyContent: "center" }}>
+      <div className={chipWrapper}>
         <StatusIcon status={data.status} />
       </div>
     ),

--- a/src/view/user/setting/GroupList/GroupListTable/index.css.ts
+++ b/src/view/user/setting/GroupList/GroupListTable/index.css.ts
@@ -43,3 +43,9 @@ export const visibilityBtnStyle = style({
   ...theme.font.Caption3_M_12,
   color: theme.color.white,
 });
+
+export const chipWrapper = style({
+  display: "inline-flex",
+  width: "8rem",
+  paddingLeft: "2rem",
+});


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #296 

## ✅ Done Task
  - [x] chip에 중앙 정렬 적용

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
.
## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
flex를 사용한 중앙정렬은 chip의 중앙을 기준으로 하기에 중앙+좌측 정렬을 할 수 있도록 고정 width를 곁들인 inline-flex를 사용했습니다.

`Menu`컴포넌트는 `useOutsideClick`훅을 위해 최상단에 `div`를 놨어야 했습니다. 이 `div`가 테이블의 `td`태그 안에서 1차적으로 레이아웃을 잡고 있기에 자식 요소에 위치 관련 스타일을 부여할 때 선택지는 다음과 같습니다.
1. `td`에 중앙정렬 스타일 적용
2. `Menu` > `div`에 적용
3. `td`와 `Menu` 사이에 새 `div`를 추가 및 적용

1안은 모든 열에 적용되므로 사용할 수 없었고,

2안은 `Menu`컴포넌트에 `className` props 추가 및 최상위 요소인 `div`를 수정하면 됩니다.

3안은 다른 컴포넌트를 수정할 필요 없이 `div`만 사이에 넣으면 됩니다. `Menu`를 통째로 움직이는 것이므로 2안과 달리 수정해야 할 코드가 적습니다.

이에 따라 3안으로 적용했습니다.


마이페이지의 스터디 리스트에도 칩이 사용되는데, 거긴 그냥 중앙 정렬로 했었습니다. 그곳도 중앙+좌측 정렬을 적용할까요?

## 📸 Screenshot

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/38b69678-3528-4f04-824e-3d4d8bc26f95" />
