### PR TITLE
[ Fix ] 알림 삭제 시 스크롤 현상 / 캐러셀 마우스 인식 못함 에러 해결

### DIFF
--- a/src/common/component/Carousel/index.css.ts
+++ b/src/common/component/Carousel/index.css.ts
@@ -11,6 +11,7 @@ export const carouselStyle = recipe({
 
     "::before": {
       content: "",
+      pointerEvents: "none",
 
       position: "absolute",
       top: 0,
@@ -30,6 +31,7 @@ export const carouselStyle = recipe({
 
     "::after": {
       content: "",
+      pointerEvents: "none",
 
       position: "absolute",
       top: 0,

--- a/src/shared/component/Header/Notification/index.css.ts
+++ b/src/shared/component/Header/Notification/index.css.ts
@@ -29,6 +29,7 @@ export const ulStyle = style({
 
   // scroll bar
   overflowY: "scroll",
+  overflowX: "hidden",
   overscrollBehavior: "contain",
 
   height: "26.6rem",


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #310 

## ✅ Done Task
  - [x] 알림 스크롤 방지
  - [x] 캐러셀 마우스 호버, 클릭 인식

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

`css`만 수정해주었습니다. `overflowX: hidden`으로 알림 삭제 시 가로스크롤이 생기는 현상을 막고, `pointerEvent: none`으로 캐러셀 위에 존재하는 검은색 배경 요소의 마우스 이벤트를 없앰으로써 뒤 카드가 마우스를 인식할 수 있도록 하였습니다.

그리고 스터디 알림 설정 페이지에서 스위치 컴포넌트가 분명 배포 환경에서 동작하지 않았는데, `next` 프로덕션 환경에서 다시 체크해보니 잘만 동작하네요.. 그 때 리소스 부족으로 컴포넌트가 반응하지 못했던 것 같기도합니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/c2a41379-a00f-4550-9aa3-910408803f5b
