### PR TITLE
[ Fix ] 그룹 생성 데이트피커 버튼 제출 오류 / 제출 완료 시 페이지 깜빡임 해결

### DIFF
--- a/src/app/[user]/create-group/page.tsx
+++ b/src/app/[user]/create-group/page.tsx
@@ -3,21 +3,14 @@
 import Modal from "@/common/component/Modal";
 import Sidebar from "@/common/component/Sidebar";
 import ToastProvider from "@/common/component/Toast";
-import CodeClipboard from "@/shared/component/CodeClipboard";
 import { sidebarWrapper } from "@/styles/shared.css";
 import CreateGroupForm from "@/view/user/create-group/CreateGroupForm";
 
 import { wrapper } from "@/view/user/create-group/index.css";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 const CreateGroupPage = () => {
   const router = useRouter();
-  const [responseCode, setResponseCode] = useState("");
-
-  const handleSuccess = (code: string) => {
-    setResponseCode(code);
-  };
 
   return (
     <main className={sidebarWrapper}>
@@ -25,8 +18,7 @@ const CreateGroupPage = () => {
       <Sidebar />
       <Modal isOpen={true} onClose={() => router.back()} hasCloseBtn>
         <div className={wrapper}>
-          <CreateGroupForm onSuccess={handleSuccess} />
-          {responseCode && <CodeClipboard code={responseCode} />}
+          <CreateGroupForm />
         </div>
       </Modal>
     </main>

--- a/src/app/join-group/[code]/query.ts
+++ b/src/app/join-group/[code]/query.ts
@@ -1,10 +1,10 @@
 import { getGroupsByCode } from "@/app/api/groups";
 import { joinGroupAction } from "@/app/join-group/[code]/action";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
 export const useGroupByCodeQuery = (code: string) => {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ["groupByCode", code],
     queryFn: () => getGroupsByCode(code),
   });

--- a/src/common/component/Calendar/index.tsx
+++ b/src/common/component/Calendar/index.tsx
@@ -92,13 +92,21 @@ const renderCustomHeader = ({
 }: CustomHeaderProps) => {
   return (
     <div className={customHeaderWrapperStyle}>
-      <button className={arrowWrapperStyle} onClick={decreaseMonth}>
+      <button
+        type="button"
+        className={arrowWrapperStyle}
+        onClick={decreaseMonth}
+      >
         <IcnBtnArrowLeft className={leftArrowStyle({ rotate: false })} />
       </button>
       <div className={dateDetailStyle}>{`${date.getFullYear()}년 ${
         date.getMonth() + 1
       }월`}</div>
-      <button className={arrowWrapperStyle} onClick={increaseMonth}>
+      <button
+        type="button"
+        className={arrowWrapperStyle}
+        onClick={increaseMonth}
+      >
         <IcnBtnArrowLeft className={leftArrowStyle({ rotate: true })} />
       </button>
     </div>

--- a/src/shared/component/CodeClipboard/index.tsx
+++ b/src/shared/component/CodeClipboard/index.tsx
@@ -16,11 +16,14 @@ interface CodeClipboardProps {
 }
 
 const CodeClipboard = ({ label, code }: CodeClipboardProps) => {
-  const { data: groupInfo } = useGroupByCodeQuery(code);
+  const { data: groupInfo, isSuccess } = useGroupByCodeQuery(code);
+
   const { isCopied, copy } = useClipboard(
-    groupInfo?.ownerNickname,
-    groupInfo?.name,
+    groupInfo?.ownerNickname ?? "",
+    groupInfo?.name ?? "",
   );
+
+  if (!isSuccess) return null;
 
   return (
     <div className={wrapperStyle}>

--- a/src/view/user/create-group/CreateGroupForm/index.tsx
+++ b/src/view/user/create-group/CreateGroupForm/index.tsx
@@ -3,6 +3,7 @@ import { IcnPlus } from "@/asset/svg";
 import Button from "@/common/component/Button";
 import SupportingText from "@/common/component/SupportingText";
 import { useToast } from "@/common/hook/useToast";
+import CodeClipboard from "@/shared/component/CodeClipboard";
 import { Form } from "@/shared/component/Form";
 import DateFormController from "@/shared/component/GroupInfoForm/DateFormController";
 import DescFormController from "@/shared/component/GroupInfoForm/DescFormController";
@@ -16,15 +17,15 @@ import {
 } from "@/shared/component/GroupInfoForm/index.css";
 import { getGroupFormData } from "@/shared/component/GroupInfoForm/util";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import type { z } from "zod";
 import { submitBtnStyle } from "./index.css";
 
-type CreateGroupFormProps = {
-  onSuccess: (code: string) => void;
-};
-const CreateGroupForm = ({ onSuccess }: CreateGroupFormProps) => {
+const CreateGroupForm = () => {
   const { showToast } = useToast();
+  const [code, setCode] = useState("");
+
   const form = useForm<z.infer<typeof groupSchema>>({
     resolver: zodResolver(groupSchema),
     mode: "onTouched",
@@ -41,7 +42,7 @@ const CreateGroupForm = ({ onSuccess }: CreateGroupFormProps) => {
     const data = getGroupFormData(values);
     const code = await createGroupAction(data);
 
-    onSuccess(code);
+    setCode(code);
     showToast("스터디가 정상적으로 만들어졌어요.", "success");
   };
   const error = form.formState.errors.endDate;
@@ -86,6 +87,7 @@ const CreateGroupForm = ({ onSuccess }: CreateGroupFormProps) => {
           스터디 만들기
         </Button>
       </form>
+      {code && <CodeClipboard code={code} />}
     </Form>
   );
 };


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #314 

## ✅ Done Task
  - [x] 데이트피커 type button
  - [x] suspense 삭제

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

### 데이트피커 월 이동 버튼 클릭 시 제출됨

당연하게도 button의 타입이 기본 타입인 `submit` 으로 되어있어서 이벤트 전파로 인해 그룹 생성 폼도 제출되는 현상이 발생했어요. 타입 수정하여 고쳐주었습니다.

### 제출 완료시 깜빡임 해결

`useGroupByCodeQuery` 훅이 `useSuspenseQuery`로 되어있었습니다. 즉 그룹 생성이 완료되고 응답 데이터로 `code`를 받게 되면 `code` 상태가 바뀌고, `Clipboard`가 렌더링되게 됩니다. 그럼 즉시 서스펜스 쿼리가 실행되고, 응답을 기다리며 펜딩 상태가 `success`가 될 때까지 컴포넌트 렌더링을 중단하는 현상이 발생해요 ! 따라서 깜빡임이 발생하고 성공 상태가 떴을 때 나머지를 렌더링하게 되었습니다.

이를 `useQuery`로 수정해주었어요. 그렇다보니 어쩔 수 없는 `undefined` 값에 대한 처리를 해줘야했습니다. `Clipboard` 컴포넌트에서 만약 `useQuery`가 `pending` 상태일 때 복사 버튼을 누르면 잘못된 초대 텍스트가 복사될 것이 우려되었습니다. 따라서 해당 쿼리의 `isSuccess` 상태를 기준으로 아직 성공상태가 아니라면 클립보드를 보여주지 않고, 성공이 떴을 때 클립보드를 렌더링해주는 방식으로 수정해주었습니다.


## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/c5c0a8f6-2e58-4fef-a50a-0eece61eb58d

