### PR TITLE
[ Fix ] active 상태, 드롭다운 잘림 수정

### DIFF
--- a/src/common/component/Menu/Menu.tsx
+++ b/src/common/component/Menu/Menu.tsx
@@ -4,7 +4,12 @@ import { useOutsideClick } from "@/common/hook/useOutsideClick";
 import { handleA11yClick } from "@/common/util/dom";
 import { camelToKebab } from "@/common/util/string";
 import { Slot } from "@radix-ui/react-slot";
-import { type ReactNode, useState } from "react";
+import {
+  type ReactNode,
+  forwardRef,
+  useImperativeHandle,
+  useState,
+} from "react";
 import { defaultButtonStyle } from "./Menu.css";
 
 type MenuProps = {
@@ -18,48 +23,66 @@ type MenuProps = {
    * **부여되는 속성**: `id`, `aria-labelledby`<br><hr>
    */
   renderList: ReactNode;
+
+  onClick?: () => void;
 };
 
+export type MenuRef = {
+  toggleMenu: () => void;
+  menuRef: React.RefObject<HTMLElement>;
+};
 /**
  * trigger button과 list에 토글 기능과 필요한 aria속성을 부여해주는 컴포넌트<br>
  * **`renderTriggerButton`은 꼭 clsx를 사용해 className을 결합해야 함**
  */
-const Menu = ({ label, renderTriggerButton, renderList }: MenuProps) => {
-  const [showMenu, setShowMenu] = useState(false);
-  const handleClick = () => setShowMenu(!showMenu);
-  const handleClose = () => setShowMenu(false);
-  const ref = useOutsideClick(handleClose);
-  const triggerId = camelToKebab(`${label}Toggle`);
-  const menuId = camelToKebab(label);
 
-  return (
-    <div ref={ref}>
-      <Slot
-        className={defaultButtonStyle}
-        id={triggerId}
-        aria-label={`${showMenu ? "Close" : "Open"} ${menuId}`}
-        aria-haspopup="true"
-        aria-expanded={showMenu}
-        aria-controls={menuId}
-        onClick={handleClick}
-        onKeyDown={handleA11yClick(handleClick)}
-        tabIndex={0}
-      >
-        {renderTriggerButton}
-      </Slot>
+const Menu = forwardRef(
+  ({ label, renderTriggerButton, renderList, onClick }: MenuProps, ref) => {
+    const [showMenu, setShowMenu] = useState(false);
+    const handleClick = () => setShowMenu(!showMenu);
+    const handleClose = () => setShowMenu(false);
+    const outsideClickRef = useOutsideClick(handleClose);
+    const triggerId = camelToKebab(`${label}Toggle`);
+    const menuId = camelToKebab(label);
 
-      {showMenu && (
+    useImperativeHandle(
+      ref,
+      () =>
+        ({
+          toggleMenu: handleClick,
+          menuRef: outsideClickRef,
+        }) as MenuRef,
+    );
+
+    return (
+      <div ref={outsideClickRef}>
         <Slot
-          id={menuId}
-          aria-labelledby={triggerId}
-          onClick={handleClose}
-          onKeyDown={handleA11yClick(handleClose)}
+          className={defaultButtonStyle}
+          id={triggerId}
+          aria-label={`${showMenu ? "Close" : "Open"} ${menuId}`}
+          aria-haspopup="true"
+          aria-expanded={showMenu}
+          aria-controls={menuId}
+          onClick={onClick || handleClick}
+          onKeyDown={handleA11yClick(handleClick)}
+          tabIndex={0}
         >
-          {renderList}
+          {renderTriggerButton}
         </Slot>
-      )}
-    </div>
-  );
-};
+
+        {showMenu && (
+          <Slot
+            id={menuId}
+            aria-labelledby={triggerId}
+            onClick={handleClose}
+            onKeyDown={handleA11yClick(handleClose)}
+          >
+            {renderList}
+          </Slot>
+        )}
+      </div>
+    );
+  },
+);
 
 export default Menu;

--- a/src/shared/hook/useIntersectionObserver.ts
+++ b/src/shared/hook/useIntersectionObserver.ts
@@ -1,22 +1,22 @@
 import { useEffect, useRef } from "react";
 
-export const useFadeIn = <T extends HTMLElement>(
+export const useIntersectionObserver = <T extends HTMLElement>(
   callback: IntersectionObserverCallback,
 ) => {
-  const imageRef = useRef<T>(null);
+  const elemntRef = useRef<T>(null);
 
   useEffect(() => {
-    if (!imageRef.current) return;
+    if (!elemntRef.current) return;
     const observer = new IntersectionObserver(callback, { threshold: 0.1 });
 
-    observer.observe(imageRef.current);
+    observer.observe(elemntRef.current);
 
     return () => {
-      if (imageRef.current) {
-        observer.unobserve(imageRef.current);
+      if (elemntRef.current) {
+        observer.unobserve(elemntRef.current);
       }
     };
   }, []);
 
-  return imageRef;
+  return elemntRef;
 };

--- a/src/view/group/setting/MemberList/RoleList/RoleDropdownMenu.tsx
+++ b/src/view/group/setting/MemberList/RoleList/RoleDropdownMenu.tsx
@@ -33,7 +33,7 @@ const RoleDropdownMenu = () => {
         </div>
       }
       renderList={
-        <Dropdown className={dropdownStyle}>
+        <Dropdown className={dropdownStyle()}>
           {Object.keys(ROLE).map((role) => {
             const handleClick = () => handleFilterChange(role as Role);
             return (

--- a/src/view/group/setting/MemberList/constant.tsx
+++ b/src/view/group/setting/MemberList/constant.tsx
@@ -131,7 +131,9 @@ export const MEMBER_LIST_COLUMNS: TableDataType<MemberResponse>[] = [
                   return (
                     <li
                       key={role}
-                      onClick={() => handleListClick(role as Role, data.memberId)}
+                      onClick={() =>
+                        handleListClick(role as Role, data.memberId)
+                      }
                       onKeyDown={handleA11yClick(() =>
                         handleListClick(role as Role, data.memberId),
                       )}

--- a/src/view/group/setting/MemberList/constant.tsx
+++ b/src/view/group/setting/MemberList/constant.tsx
@@ -1,9 +1,10 @@
 import type { MemberResponse, Role } from "@/app/api/groups/type";
 import { IcnCalendarTable, IcnClose } from "@/asset/svg";
 import Dropdown from "@/common/component/Dropdown";
-import Menu from "@/common/component/Menu/Menu";
+import Menu, { type MenuRef } from "@/common/component/Menu/Menu";
 import { handleA11yClick } from "@/common/util/dom";
 import { ROLE } from "@/shared/constant/role";
+import { useIntersectionObserver } from "@/shared/hook/useIntersectionObserver";
 import type { TableDataType } from "@/shared/type/table";
 import RoleChip from "@/view/group/setting/MemberList/RoleList/RoleChip";
 import {
@@ -19,6 +20,8 @@ import {
 } from "@/view/group/setting/MemberList/index.css";
 import SortIcon from "@/view/user/setting/GroupList/SortIcon";
 import { dropdownStyle } from "@/view/user/setting/GroupList/StatusDropdownMenu/index.css";
+import clsx from "clsx";
+import { useRef, useState } from "react";
 import { chipWrapper } from "./RoleList/index.css";
 
 export const MEMBER_LIST_COLUMNS: TableDataType<MemberResponse>[] = [
@@ -74,13 +77,28 @@ export const MEMBER_LIST_COLUMNS: TableDataType<MemberResponse>[] = [
   },
   {
     key: "role",
-    // Header: () => <RoleDropdownMenu />,
     Header: () => "역할",
     Cell: (data) => {
+      const [isIntersection, setIsIntersection] = useState(false);
+      const [direction, setDirection] = useState<"down" | "up">("down");
+      const menuRef = useRef<MenuRef>(null);
+      const ref = useIntersectionObserver<HTMLDivElement>(([entry]) => {
+        setIsIntersection(entry.isIntersecting);
+      });
       const handleOwnerChange = useChangeOwner();
       const patchMutate = usePatchMemberRoleMutation();
 
-      const handleClick = (role: Role, memberId: number) => {
+      const handleButtonClick = () => {
+        const showedBtns = Array.from(
+          document.querySelectorAll(".intersection"),
+        );
+
+        const index = showedBtns.findIndex((btn) => btn === ref.current);
+        setDirection(index >= showedBtns.length - 3 ? "up" : "down");
+        menuRef.current?.toggleMenu();
+      };
+
+      const handleListClick = (role: Role, memberId: number) => {
         if (role === "OWNER") {
           handleOwnerChange(data.memberId, data.nickname);
           return;
@@ -91,27 +109,31 @@ export const MEMBER_LIST_COLUMNS: TableDataType<MemberResponse>[] = [
       return (
         <div className={chipWrapper}>
           <Menu
+            ref={menuRef}
             label="role"
+            onClick={handleButtonClick}
             renderTriggerButton={
               <div
                 style={{
                   display: "flex",
                   width: "fit-content",
                 }}
+                ref={ref}
+                className={clsx(isIntersection && "intersection")}
               >
                 <RoleChip role={data.role as Role} />
               </div>
             }
             renderList={
-              <Dropdown className={dropdownStyle}>
+              <Dropdown className={dropdownStyle({ direction })}>
                 {Object.keys(ROLE).map((role) => {
                   if (role === data.role) return;
                   return (
                     <li
                       key={role}
-                      onClick={() => handleClick(role as Role, data.memberId)}
+                      onClick={() => handleListClick(role as Role, data.memberId)}
                       onKeyDown={handleA11yClick(() =>
-                        handleClick(role as Role, data.memberId),
+                        handleListClick(role as Role, data.memberId),
                       )}
                     >
                       <RoleChip role={role as Role} />

--- a/src/view/onboarding/Section/FadeInImage.tsx
+++ b/src/view/onboarding/Section/FadeInImage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useFadeIn } from "@/shared/hook/useIntersectionObserver";
+import { useIntersectionObserver } from "@/shared/hook/useIntersectionObserver";
 import type { HTMLAttributes, PropsWithChildren } from "react";
 import { fadeInStyle } from "./index.css";
 
@@ -9,7 +9,7 @@ interface ImageProps
     HTMLAttributes<HTMLDivElement> {}
 
 const FadeInImage = ({ children, ...props }: ImageProps) => {
-  const imageRef = useFadeIn<HTMLDivElement>(function (
+  const imageRef = useIntersectionObserver<HTMLDivElement>(function (
     this: IntersectionObserver,
     [e],
   ) {

--- a/src/view/user/setting/GroupList/StatusDropdownMenu/index.css.ts
+++ b/src/view/user/setting/GroupList/StatusDropdownMenu/index.css.ts
@@ -30,3 +30,7 @@ export const textStyle = style({
   ...theme.font.Caption3_M_12,
   color: theme.color.mg2,
 });
+
+export const activeStyle = style({
+  backgroundColor: theme.color.mg5,
+});

--- a/src/view/user/setting/GroupList/StatusDropdownMenu/index.css.ts
+++ b/src/view/user/setting/GroupList/StatusDropdownMenu/index.css.ts
@@ -18,6 +18,8 @@ export const arrowDownStyle = style({
 
 export const dropdownStyle = style({
   transform: "translate(0, 8px)",
+  position: "absolute",
+  zIndex: theme.zIndex.top,
 
   paddingTop: "1.6rem",
   paddingBottom: "1.6rem",

--- a/src/view/user/setting/GroupList/StatusDropdownMenu/index.css.ts
+++ b/src/view/user/setting/GroupList/StatusDropdownMenu/index.css.ts
@@ -1,5 +1,6 @@
 import { theme } from "@/styles/themes.css";
 import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
 
 export const triggerButtonStyle = style({
   display: "flex",
@@ -16,15 +17,28 @@ export const arrowDownStyle = style({
   height: "1.2rem",
 });
 
-export const dropdownStyle = style({
-  transform: "translate(0, 8px)",
-  position: "absolute",
-  zIndex: theme.zIndex.top,
-
-  paddingTop: "1.6rem",
-  paddingBottom: "1.6rem",
-  ":hover": {
-    opacity: 0.9,
+export const dropdownStyle = recipe({
+  base: {
+    position: "absolute",
+    zIndex: theme.zIndex.top,
+    paddingTop: "1.6rem",
+    paddingBottom: "1.6rem",
+    ":hover": {
+      opacity: 0.9,
+    },
+  },
+  variants: {
+    direction: {
+      down: {
+        transform: "translate(0, .8rem)",
+      },
+      up: {
+        transform: "translate(0, -14.2rem)",
+      },
+    },
+  },
+  defaultVariants: {
+    direction: "down",
   },
 });
 

--- a/src/view/user/setting/GroupList/StatusDropdownMenu/index.tsx
+++ b/src/view/user/setting/GroupList/StatusDropdownMenu/index.tsx
@@ -42,7 +42,7 @@ const StatusDropdownMenu = () => {
         </div>
       }
       renderList={
-        <Dropdown className={dropdownStyle}>
+        <Dropdown className={dropdownStyle()}>
           {statusOptions.map(({ label, icon }) => {
             const handleClick = () => handleFilterChange(label);
             return (

--- a/src/view/user/setting/GroupList/StatusDropdownMenu/index.tsx
+++ b/src/view/user/setting/GroupList/StatusDropdownMenu/index.tsx
@@ -43,7 +43,7 @@ const StatusDropdownMenu = () => {
       }
       renderList={
         <Dropdown className={dropdownStyle}>
-          {statusOptions.map(({label, icon}) => {
+          {statusOptions.map(({ label, icon }) => {
             const handleClick = () => handleFilterChange(label);
             return (
               <li

--- a/src/view/user/setting/GroupList/StatusDropdownMenu/index.tsx
+++ b/src/view/user/setting/GroupList/StatusDropdownMenu/index.tsx
@@ -2,14 +2,19 @@ import { IcnBtnArrowDown } from "@/asset/svg";
 import Dropdown from "@/common/component/Dropdown";
 import Menu from "@/common/component/Menu/Menu";
 import { handleA11yClick } from "@/common/util/dom";
-import { useGroupListDispatch } from "@/view/user/setting/GroupList/GroupListTable/hook";
 import {
+  useGroupListDispatch,
+  useGroupListState,
+} from "@/view/user/setting/GroupList/GroupListTable/hook";
+import {
+  activeStyle,
   arrowDownStyle,
   dropdownStyle,
   textStyle,
   triggerButtonStyle,
 } from "@/view/user/setting/GroupList/StatusDropdownMenu/index.css";
 import StatusIcon from "@/view/user/setting/GroupList/StatusIcon";
+import clsx from "clsx";
 
 const statusOptions = [
   { label: "inProgress", icon: <StatusIcon status="inProgress" /> },
@@ -18,6 +23,7 @@ const statusOptions = [
 ];
 const StatusDropdownMenu = () => {
   const dispatch = useGroupListDispatch();
+  const { filterValue } = useGroupListState();
   const handleFilterChange = (status: string) => {
     dispatch({
       type: "SET_FILTER",
@@ -37,15 +43,16 @@ const StatusDropdownMenu = () => {
       }
       renderList={
         <Dropdown className={dropdownStyle}>
-          {statusOptions.map((option) => {
-            const handleClick = () => handleFilterChange(option.label);
+          {statusOptions.map(({label, icon}) => {
+            const handleClick = () => handleFilterChange(label);
             return (
               <li
-                key={option.label}
+                key={label}
+                className={clsx(label === filterValue && activeStyle)}
                 onClick={handleClick}
                 onKeyDown={handleA11yClick(handleClick)}
               >
-                {option.icon}
+                {icon}
               </li>
             );
           })}


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #317 

## ✅ Done Task
  - [x] active 상태
  - [x] 메뉴 드롭다운 잘림 현상

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 드롭다운 열림 방향 정하기
1. intersection observer로 감지된 버튼들을 찾습니다. observer callback의 속성 중 화면에 표시된건지 가려진건지 여부를 알 수 있는 `isIntersecting`을 사용합니다.
찾은 버튼들을 저장하기 위한 여러 방법들 중 간단하게 class(".intersection")를 부여하는 방법을 선택했습니다.
2. 버튼 클릭 시 `querySelectorAll(".intersection")`과 ref를 사용해 버튼의 index를 확인합니다.
3. index가 마지막 3개면 위로 열리도록 `setState`(바익 `recipe`에 연결)를 up으로 설정합니다. 아닐경우 down입니다.

화면에 표시/제거될때, 버튼을 클릭할때만 계산하므로 성능이 좋습니다.

- 수정사항
  - 드롭다운 토글 함수를 쓰기 위해 Menu 컴포넌트를 `forwardRef`로 만들었습니다. 
  - 랜딩페이지에서 쓰던 `useFadeIn`을 쓰임새에 맞는 변수명인 `useIntersectionObserver`로 변경했습니다.
 
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
- 드롭다운
![SmartSelect_20250125_202302_Chrome](https://github.com/user-attachments/assets/582f9ed7-2a6f-49fd-82a4-2dd3bd4298ca)

- 활성된 상태 필터값 호버 이펙트
![SmartSelect_20250125_200548_Chrome](https://github.com/user-attachments/assets/79b95077-1b00-457a-a36c-3f910b98091a)