### PR TITLE
[ Fix ] 문제리스트 페이지 새로고침 이슈

### DIFF
--- a/src/app/group/[groupId]/problem-list/query.ts
+++ b/src/app/group/[groupId]/problem-list/query.ts
@@ -12,8 +12,8 @@ import { useToast } from "@/common/hook/useToast";
 import { HTTP_ERROR_STATUS } from "@/shared/constant/api";
 import {
   useMutation,
-  useQueryClient,
-  useSuspenseQuery,
+  useQuery,
+  useQueryClient
 } from "@tanstack/react-query";
 import type { HTTPError } from "ky";
 
@@ -82,7 +82,7 @@ export const useDeleteProblemMutation = (groupId: number) => {
 };
 
 export const useProblemInfoQuery = (problemId: number) => {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ["problem", problemId],
     queryFn: () => getProblemInfo(problemId),
   });

--- a/src/app/group/[groupId]/problem-list/query.ts
+++ b/src/app/group/[groupId]/problem-list/query.ts
@@ -10,11 +10,7 @@ import {
 } from "@/app/group/[groupId]/problem-list/action";
 import { useToast } from "@/common/hook/useToast";
 import { HTTP_ERROR_STATUS } from "@/shared/constant/api";
-import {
-  useMutation,
-  useQuery,
-  useQueryClient
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { HTTPError } from "ky";
 
 export const usePostProblemMutation = (groupId: number) => {

--- a/src/shared/component/ProblemList/ProblemEdit.tsx
+++ b/src/shared/component/ProblemList/ProblemEdit.tsx
@@ -63,7 +63,7 @@ const ProblemEdit = ({ problemId, isActive }: ProblemEditProps) => {
         <PatchForm
           onDelete={handleDelete}
           onSubmit={handleEditSubmit}
-          problemInfo={problemInfo}
+          problemInfo={problemInfo!}
         />
       </Modal>
     </>

--- a/src/shared/hook/usePaginationQuery.ts
+++ b/src/shared/hook/usePaginationQuery.ts
@@ -1,6 +1,6 @@
 import type { PaginationResponse } from "@/app/api/type";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 type UsePaginationQueryProps<T> = {
   queryKey: (string | number | object)[];
@@ -14,7 +14,6 @@ export const usePaginationQuery = <T>({
   initialPage = 1,
 }: UsePaginationQueryProps<T>) => {
   const [currentPage, setCurrentPage] = useState(initialPage);
-  const [totalPages, setTotalPages] = useState<number>(0);
 
   const query = useQuery({
     queryKey: [...queryKey, currentPage],
@@ -22,9 +21,10 @@ export const usePaginationQuery = <T>({
     placeholderData: keepPreviousData,
   });
 
-  useEffect(() => {
-    setTotalPages((query.data as PaginationResponse)?.totalPages || 0);
-  }, [...queryKey]);
-
-  return { ...query, currentPage, setCurrentPage, totalPages };
+  return {
+    ...query,
+    currentPage,
+    setCurrentPage,
+    totalPages: (query.data as PaginationResponse)?.totalPages || 1,
+  };
 };

--- a/src/view/group/problem-list/ProblemSection/index.tsx
+++ b/src/view/group/problem-list/ProblemSection/index.tsx
@@ -1,4 +1,6 @@
 import type { ProblemContent } from "@/app/api/problems/type";
+import Pagination from "@/shared/component/Pagination";
+import ProblemList from "@/shared/component/ProblemList";
 import ProgressList from "@/view/group/problem-list";
 import { titleStyle } from "@/view/group/problem-list/index.css";
 
@@ -27,6 +29,8 @@ const ProblemSection = ({
         <div>
           <h2 className={titleStyle}>{title}</h2>
         </div>
+        <ProblemList.Header />
+
         {list?.length && (
           <ProgressList
             data={list}
@@ -37,6 +41,13 @@ const ProblemSection = ({
             isExpired={isExpired}
           />
         )}
+
+        <Pagination
+          style={{ marginTop: "1.6rem" }}
+          totalPages={totalPages}
+          currentPage={currentPage}
+          onPageChange={onPageChange}
+        />
       </div>
     </section>
   );

--- a/src/view/group/problem-list/index.tsx
+++ b/src/view/group/problem-list/index.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import type { ProblemContent } from "@/app/api/problems/type";
-import {} from "@/app/group/[groupId]/problem-list/query";
-import Pagination from "@/shared/component/Pagination";
 import ProblemList from "@/shared/component/ProblemList";
-import ProblemListHeader from "@/view/group/dashboard/ProblemListHeader";
 
 type ProgressListProps = {
   data: ProblemContent[];
@@ -18,14 +15,10 @@ type ProgressListProps = {
 const ProgressList = ({
   data,
   isOwner,
-  totalPages,
-  currentPage,
-  onPageChange,
   isExpired = false,
 }: ProgressListProps) => {
   return (
     <>
-      <ProblemListHeader />
       <ProblemList>
         {data.map((item) => (
           <ProblemList.Item
@@ -36,12 +29,6 @@ const ProgressList = ({
           />
         ))}
       </ProblemList>
-      <Pagination
-        style={{ marginTop: "1.6rem" }}
-        totalPages={totalPages}
-        currentPage={currentPage}
-        onPageChange={onPageChange}
-      />
     </>
   );
 };


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #327 

## ✅ Done Task
  - [x] suspense 제거
  - [x] 코드 정리

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
suspense query를 사용할 땐 `<Suspense>` 컴포넌트와 `loading 컴포넌트`를 준비하고 사용하도록 해요. (next.js streaming)
이 둘 없이 suspence query를 사용한 까닭에 화면이 suspense(데이터 로딩)동안 깜빡인거였습니다.

지금은 그냥 `useQuery`로 처리했지만, 완성도 높은 개발이 목표라면 나중에 위 3가지를 적용하는게 좋겠어요!

- 변경사항
1. `usePaginationQuery`의 `totalPages` 상태는 서버상태를 사용해도 되므로 제거했습니다.
2. 문제리스트 컴포넌트는 추후에 streaming 방식 적용을 위해 미리 컴포넌트를 분리했습니다.
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->