### PR TITLE
[ Fix ] 비 로그인 유저의 그룹 페이지 접근시 안내 모달 출력

### DIFF
--- a/src/app/[user]/page.tsx
+++ b/src/app/[user]/page.tsx
@@ -4,6 +4,7 @@ import { getGroupsByUsers } from "@/app/api/users";
 import { auth } from "@/auth";
 import Sidebar from "@/common/component/Sidebar";
 import { sidebarWrapper } from "@/styles/shared.css";
+import LoginAlertModalController from "@/view/user/index/GroupCard/LoginAlertModalController";
 import ListSection from "@/view/user/index/ListSection";
 import UserCard from "@/view/user/index/UserCard";
 import { userCardWrapper } from "@/view/user/index/UserCard/index.css";
@@ -48,6 +49,7 @@ const UserDashboardPage = async ({
           />
         ))}
       </div>
+      <LoginAlertModalController />
     </main>
   );
 };

--- a/src/shared/component/LoginAlertModal/index.tsx
+++ b/src/shared/component/LoginAlertModal/index.tsx
@@ -21,7 +21,10 @@ const LoginAlertModal = ({
 }: LoginAlertModalProps) => {
   const router = useRouter();
 
-  const handleRedirectToLogin = () => router.push("/login");
+  const handleRedirectToLogin = () => {
+    onClose();
+    router.push("/login");
+  };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} hasCloseBtn>

--- a/src/shared/component/ProtectedLink/index.tsx
+++ b/src/shared/component/ProtectedLink/index.tsx
@@ -1,0 +1,19 @@
+import { loginAlertModalAtom } from "@/shared/store/alertModal";
+import { useSetAtom } from "jotai";
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import type { ComponentProps, MouseEvent } from "react";
+
+const ProtectedLink = (props: ComponentProps<typeof Link>) => {
+  const handleShowModal = useSetAtom(loginAlertModalAtom);
+  const { status: authStatus } = useSession();
+  const handleClick = (e: MouseEvent) => {
+    if (authStatus === "unauthenticated") {
+      e.preventDefault();
+      handleShowModal(true);
+    }
+  };
+  return <Link {...props} onClick={handleClick} />;
+};
+
+export default ProtectedLink;

--- a/src/shared/store/alertModal.ts
+++ b/src/shared/store/alertModal.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const loginAlertModalAtom = atom(false);

--- a/src/shared/util/form.ts
+++ b/src/shared/util/form.ts
@@ -85,7 +85,7 @@ export const createFormDataFromDirtyFields = <T extends z.ZodRawShape>(
 
       return acc;
     },
-    {} as Record<string, ValueType>,
+    { isDefaultImage: true } as Record<string, ValueType>,
   );
   data.append("request", JSON.stringify(requestData));
   return data;

--- a/src/view/user/index/GroupCard/LoginAlertModalController.tsx
+++ b/src/view/user/index/GroupCard/LoginAlertModalController.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import LoginAlertModal from "@/shared/component/LoginAlertModal";
+import { loginAlertModalAtom } from "@/shared/store/alertModal";
+import { useAtom } from "jotai";
+
+const LoginAlertModalController = () => {
+  const [isOpen, setIsOpen] = useAtom(loginAlertModalAtom);
+  return <LoginAlertModal isOpen={isOpen} onClose={() => setIsOpen(false)} />;
+};
+
+export default LoginAlertModalController;

--- a/src/view/user/index/GroupCard/index.tsx
+++ b/src/view/user/index/GroupCard/index.tsx
@@ -1,6 +1,7 @@
 import type { GroupResponse, GroupStatus } from "@/app/api/groups/type";
 import defaultImg from "@/asset/img/img_card_profile.png";
 import { IcnCalenderCard, IcnUser, IcnUser2 } from "@/asset/svg";
+import ProtectedLink from "@/shared/component/ProtectedLink";
 import StatusDot from "@/view/user/index/GroupCard/StatusDot";
 import {
   dateStyle,
@@ -12,7 +13,6 @@ import {
   ownerStyle,
 } from "@/view/user/index/GroupCard/index.css";
 import Image from "next/image";
-import Link from "next/link";
 
 interface GroupCardProps {
   item: GroupResponse;
@@ -23,7 +23,7 @@ const GroupCard = ({ item, status }: GroupCardProps) => {
   const isDone = status === "done";
 
   return (
-    <Link href={`/group/${id}`}>
+    <ProtectedLink href={`/group/${id}`}>
       <article className={groupCardWrapper}>
         <Image
           src={groupImage || defaultImg}
@@ -52,7 +52,7 @@ const GroupCard = ({ item, status }: GroupCardProps) => {
           <p className={descStyle({ isDone })}>{ownerNickname}</p>
         </div>
       </article>
-    </Link>
+    </ProtectedLink>
   );
 };
 


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #328 

## ✅ Done Task
  - [x] jotai로 관리되는 `LoginAlertModal` 컴포넌트 생성
  - [x] 비 로그인 유저는 `LoginAlertModal`로 연결되는 `ProtectedLink`컴포넌트 생성
  - [x] 적용 및 테스트

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 구현 과정
1. 처음엔 단순히 각 카드에 `LoginAlertModal`삽입하려고 했으나 쓰지 않을 중복된 모달들이 생성되는 이슈가 신경쓰여서 이 방법은 폐기했습니다.
2. 1의 대안으로 전역 `LoginAlertModal`을 두고 다른 컴포넌트에서  `jotai`를 통해 모달을 열어야겠다고 생각하여  일단 page에 놨습니다.
3. `useBooleanState`처럼 사용할 `loginAlertModalAtom`과 이것이 적용된 `LoginAlertModal`인 `LoginAlertModalController`를 만들었습니다. 서버 컴포넌트인 page의 자식으로 사용하기 위해서기도 합니다.
4. `Link`컴포넌트도 3번과 비슷하게 `loginAlertModalAtom`을 결합한 `ProtectedLink`로 감쌌습니다. 비 로그인 유저가 링크를 클릭하면 `e.preventDefault`로 이동을 막고 모달을 띄웁니다.

혹시 다른곳에서도 쓰게 된다면 `LoginAlertModalController`를 더 상위 page나 layout으로 옮기고 `ProtectedLink`를 사용하면 되겠습니다.
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/1bc53eb6-276b-454c-b650-ed4a291ddb29


