### PR TITLE
Fix: migrate atrifact version to v4

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -59,17 +59,18 @@ jobs:
         shell: bash
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: algohub
           path: algohub.zip
+          overwrite: true
   deploy:
     needs: build
     runs-on: ubuntu-latest
 
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: algohub
           path: algohub.zip


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #335 

리뷰희망 : ASAP

## ✅ Done Task
  - [x] 배포 과정에서 사용하는 github artifact의 버전을 v4로 올립니다.

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
Artifact는 기본적으로 90동안 유지됩니다. 동일 이름에 대해 재업로드시 더이상 Implicit overwrite가 적용되지 않아, 명시적으로 작성해줍니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->