### PR TITLE
[ Fix ] prefetch 적용

### DIFF
--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,13 +1,15 @@
 import { getGroupInfo, getGroupMemberList } from "@/app/api/groups";
-import { getTopRanking } from "@/app/api/groups/ranking";
+import { getAllRanking, getTopRanking } from "@/app/api/groups/ranking";
 import { getDeadlineReachedProblems } from "@/app/api/problems";
 import { listSectionStyle, titleStyle } from "@/app/group/[groupId]/page.css";
 import Sidebar from "@/common/component/Sidebar";
 import ProblemList from "@/shared/component/ProblemList";
+import { prefetchQuery } from "@/shared/util/prefetch";
 import { sidebarWrapper } from "@/styles/shared.css";
 import GroupSidebar from "@/view/group/dashboard/GroupSidebar";
 import NoticeBanner from "@/view/group/dashboard/NoticeBanner";
 import Ranking from "@/view/group/dashboard/Ranking";
+import { HydrationBoundary } from "@tanstack/react-query";
 
 const GroupDashboardPage = async ({
   params: { groupId },
@@ -25,6 +27,12 @@ const GroupDashboardPage = async ({
       deadlineReachedData,
     ]);
 
+  const firstPage = 1;
+  const dehydratedState = await prefetchQuery({
+    queryKey: ["ranking", +groupId, firstPage],
+    queryFn: () => getAllRanking(+groupId, 0),
+  });
+
   return (
     <main className={sidebarWrapper}>
       <Sidebar>
@@ -32,7 +40,9 @@ const GroupDashboardPage = async ({
       </Sidebar>
       <div className={listSectionStyle}>
         <NoticeBanner />
-        <Ranking rankingData={rankingInfo} />
+        <HydrationBoundary state={dehydratedState}>
+          <Ranking rankingData={rankingInfo} />
+        </HydrationBoundary>
         <h2 className={titleStyle}>풀어야 할 문제</h2>
         <section>
           <ProblemList.Header />

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -2,12 +2,8 @@
 
 import ToastProvider from "@/common/component/Toast";
 import JotaiProvider from "@/shared/component/Provider";
+import QueryProvider from "@/shared/component/QueryProvider";
 import RefreshTokenExpireTime from "@/shared/component/RefreshTokenExpireTime";
-import {
-  QueryClient,
-  QueryClientProvider,
-  isServer,
-} from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
@@ -24,36 +20,11 @@ type ProvidersProps = {
   children: ReactNode;
 };
 
-const createQueryClient = () => {
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: 60 * 1000,
-      },
-    },
-  });
-};
-
-let browserQueryClient: QueryClient | undefined = undefined;
-
-const getQueryClient = () => {
-  if (isServer) {
-    return createQueryClient();
-  }
-  if (!browserQueryClient) {
-    browserQueryClient = createQueryClient();
-  }
-
-  return browserQueryClient;
-};
-
 const Providers = ({ children }: ProvidersProps) => {
-  const queryClient = getQueryClient();
-
   const { data: session, update } = useSession();
 
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryProvider>
       <RefreshTokenExpireTime session={session} update={update} />
       <BrowserProvider>
         <JotaiProvider>
@@ -62,7 +33,7 @@ const Providers = ({ children }: ProvidersProps) => {
         </JotaiProvider>
       </BrowserProvider>
       <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    </QueryProvider>
   );
 };
 

--- a/src/shared/component/QueryProvider/index.tsx
+++ b/src/shared/component/QueryProvider/index.tsx
@@ -3,12 +3,24 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 
-export default function QueryProvider({
+const createQueryClient = () => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+};
+
+const QueryProvider = ({
   children,
 }: {
   children: React.ReactNode;
-}) {
-  const [client] = useState(new QueryClient());
+}) => {
+  const [client] = useState(createQueryClient());
 
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
-}
+};
+
+export default QueryProvider;

--- a/src/shared/util/prefetch.ts
+++ b/src/shared/util/prefetch.ts
@@ -1,4 +1,8 @@
-import { QueryClient, type QueryFunction, type SkipToken, dehydrate } from "@tanstack/react-query";
+import {
+  QueryClient,
+  type QueryFunction,
+  dehydrate,
+} from "@tanstack/react-query";
 import { cache } from "react";
 
 const getQueryClient = cache(() => {
@@ -11,12 +15,29 @@ const getQueryClient = cache(() => {
   });
 });
 
-export const prefetchQuery = async ({ queryKey, queryFn }: {queryKey: (string|number)[], queryFn: QueryFunction | SkipToken;}) => {
+export const prefetchQuery = async ({
+  queryKey,
+  queryFn,
+}: { queryKey: (string | number)[]; queryFn: QueryFunction }) => {
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
     queryKey,
-    queryFn
+    queryFn,
   });
+
+  return dehydrate(queryClient);
+};
+
+export const prefetchQueries = async (
+  queries: { queryKey: (string | number)[]; queryFn: QueryFunction }[],
+) => {
+  const queryClient = getQueryClient();
+
+  await Promise.all(
+    queries.map(({ queryKey, queryFn }) =>
+      queryClient.prefetchQuery({ queryKey, queryFn }),
+    ),
+  );
 
   return dehydrate(queryClient);
 };

--- a/src/shared/util/prefetch.ts
+++ b/src/shared/util/prefetch.ts
@@ -1,0 +1,22 @@
+import { QueryClient, type QueryFunction, type SkipToken, dehydrate } from "@tanstack/react-query";
+import { cache } from "react";
+
+const getQueryClient = cache(() => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+});
+
+export const prefetchQuery = async ({ queryKey, queryFn }: {queryKey: (string|number)[], queryFn: QueryFunction | SkipToken;}) => {
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery({
+    queryKey,
+    queryFn
+  });
+
+  return dehydrate(queryClient);
+};


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #339 

## ✅ Done Task
  - [x] prefetch 추상화 함수 구현
  - [x] 전체 랭킹에 적용

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
서버에서 미리 데이터를 캐싱해놓고 그 캐싱 데이터를 html과 함께 클라이언트에  전달해주는 기능인 react query prefetch를 적용했습니다.

기존에는 이 prefetch기능이 없었어서 top 3 -> all 로 랭킹 탭을 전환할 때 all 랭킹의 값을 불러오는 도중 잠깐 빈 데이터를 보여주는 바람에 깜빡이는 현상이 발생했었습니다.

- Next.js에서 React Query를 이용한 prefetch는 다음 순서로 진행됩니다.

  1. 서버에서 데이터를 미리 가져옴 
  `prefetchQuery(...)`, `prefetchQueries(...)`에 `queryKey`와 `queryFn`을 전달하여 서버에서 데이터를 불러옵니다.

  2. 가져온 데이터를 `dehydrate()`로 직렬화
  `QueryClient`를 활용하여 데이터를 미리 로드(캐싱)한 후, `dehydrate()`를 사용해 캐시 데이터를 JSON 형태로 변환됩니다.

  3. `<HydrationBoundary>`를 사용해 클라이언트에서 prefetch된 데이터를 즉시 활용
   `dehydrate()` 데이터를 `HydrationBoundary`의 state 속성으로 전달하면, 클라이언트 측에도 캐싱되어 해당 데이터를 재요청 없이 사용할 수 있습니다. (클라이언트의 QueryClient에 저장됨 - query dev tools에서 확인 가능)

  4. 클라이언트에서는 `useQuery`로 prefetch된 데이터를 사용

- `cache()` (import from "react")
`prefetchQuery` 함수의 구현체를 보면 `cache`로 감싸져서 `QueryClient`의 인스턴스를 반환하는걸 확인할 수 있습니다.
  ```typescript
  const getQueryClient = cache(() => new QueryClient());
  ```
  이 `cache()`의 역할은 한 요청에 대한 처리 과정 동안 동일한 `QueryClient`인스턴스를 사용하게 하기 위함입니다. 어떤 한 요청에 대한 응답으로 서버 컴포넌트가 몇 가지 사용된다고 가정해 봅시다. 그때 컴포넌트마다 new만 사용해 인스턴스를 새로 생성하게 하면 사용된 컴포넌트 개수만큼 인스턴스가 생성될 것입니다. `cache()`를 사용하면 동일한 요청을 처리하는 동안은 동일한 QueryClient 인스턴스를 사용하게 되어 이를 해결해줍니다.

  ```tsx
  export default async function PostsPage() {
    return (
      <div>
        <h1>Blog Posts</h1>
        <PostsList /> // QueryClient 인스턴스를 쓰는 서버 컴포넌트
        <PostsList /> // cache()를 안 쓰면 인스턴스를 또 만들어 사용함
      </div>
    );
  }
  ```
  당연히 요청이 끝나면 모든 실행 컨텍스트는 종료되어 사라지므로 메모리 누수는 일어나지 않습니다.

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- prefetch 함수 사용법
prefetch할 대상 키와 함수를 `prefetchQuery`의 인자로 넣고, 반환값을 `HydrationBoundary`의 prop으로 전달해주면 됩니다.

```tsx
  const dehydratedState = await prefetchQuery({
    queryKey: ["ranking", +groupId, firstPage],
    queryFn: () => getAllRanking(+groupId, 0),
  });
  // ...
        <HydrationBoundary state={dehydratedState}>
          // prefetch한 데이터를 사용할 수 있는 영역
          <Ranking rankingData={rankingInfo} /> 
        </HydrationBoundary>
```

- prefetchQueries
사용 방법은 동일하며 `{ queryKey, queryFn }[ ]`을 인자로 넣어주면 됩니다.

- suspense
Suspense에 적용하기 위해 더 설정을 해 줄 수 있는데 문서 참고 바랍니다.
[공식문서](https://tanstack.com/query/v5/docs/framework/react/guides/advanced-ssr#streaming-with-server-components)
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->