### PR TITLE
[ Fix ] 잘못 사용한 react 컴포넌트 수정

### DIFF
--- a/src/shared/component/Table/TableElements/Body.tsx
+++ b/src/shared/component/Table/TableElements/Body.tsx
@@ -23,7 +23,7 @@ const Body = <T,>({ rows, cols, trClassName, tdClassName }: BodyProps<T>) => {
               align={align}
               className={clsx(tableCellTextStyle, tdClassName)}
             >
-              <Cell {...(row as Attributes)} />
+              <Cell {...(row as Attributes & T)} />
             </TableCell>
           ))}
         </tr>

--- a/src/shared/component/Table/TableElements/Body.tsx
+++ b/src/shared/component/Table/TableElements/Body.tsx
@@ -23,7 +23,7 @@ const Body = <T,>({ rows, cols, trClassName, tdClassName }: BodyProps<T>) => {
               align={align}
               className={clsx(tableCellTextStyle, tdClassName)}
             >
-              <Cell {...row as Attributes} />
+              <Cell {...(row as Attributes)} />
             </TableCell>
           ))}
         </tr>

--- a/src/shared/component/Table/TableElements/Body.tsx
+++ b/src/shared/component/Table/TableElements/Body.tsx
@@ -1,5 +1,6 @@
 import type { TableDataType } from "@/shared/type/table";
 import clsx from "clsx";
+import type { Attributes } from "react";
 import TableCell from "./TableCell";
 import { tableCellTextStyle, tableRowStyle } from "./index.css";
 
@@ -22,7 +23,7 @@ const Body = <T,>({ rows, cols, trClassName, tdClassName }: BodyProps<T>) => {
               align={align}
               className={clsx(tableCellTextStyle, tdClassName)}
             >
-              {Cell(row)}
+              <Cell {...row as Attributes} />
             </TableCell>
           ))}
         </tr>

--- a/src/shared/type/table.ts
+++ b/src/shared/type/table.ts
@@ -3,7 +3,7 @@ import type { FC } from "react";
 export type TableDataType<T> = {
   key: keyof T | string | undefined;
   Header: FC;
-  Cell: FC;
+  Cell: FC<T>;
   align?: "left" | "right";
   width: number;
 };

--- a/src/shared/type/table.ts
+++ b/src/shared/type/table.ts
@@ -3,7 +3,7 @@ import type { FC } from "react";
 export type TableDataType<T> = {
   key: keyof T | string | undefined;
   Header: FC;
-  Cell: FC<T>;
+  Cell: FC;
   align?: "left" | "right";
   width: number;
 };


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #355 

## ✅ Done Task
  - [x] 잘못 사용된 코드 수정

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
멤버를 삭제하면 이전보다 더 적은 리액트 훅이 사용됐다는 에러가 나와서 금방 원인을 알 수 있었습니다. 이전에 role chip을 상단에 나타나게 했던 #303 에 의해 생긴 것이라고 판단했습니다.

제가 구현했던 Table은 테이블의 각 셀에 넣을 컴포넌트를 모아놓은 `constant.tsx`의 `Cell`컴포넌트를 `Table Body`에 반복문으로 매핑하는 방식이었죠. 확인해보니 `Table Body`컴포넌트에 작성한 코드가 문제였습니다. jsx에서 `{Copmonent(props)}` 형태로 컴포넌트를 사용하면 그 컴포넌트는 단순히 표시만 될 뿐 리액트 렌더 트리에 들어가지 않고 따로 놀게 됩니다. 그에 따라 react hook의 호출 순서도 꼬여버리게 되어 렌더링 과정에서 이전보다 더 많은/적은 훅을 사용했다는 에러와 함께 앱이 중지되고 말죠.

제네릭이 섞이다보니 타입 문제로 고생했어서 대충 작동만 되게 함수 호출 방식으로 만들었던게 화근이었습니다.. 여튼 이 부분을 수정하였고 더 이상 문제가 발생하지 않는 것을 확인했습니다.

여담으로 #259 에서 이번 PR의 변경사항을 적용했었으면 context api로 교체할 필요도 없었을 테고 이번 문제도 일어나지 않았겠지만, context api를 사용하는 방식은 더 적은 react 훅으로 구현할 수 있다는 점에서 필요한 수정이긴 했습니다.

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
현 구조에서 Table로 표시할 데이터의 타입을 컴포넌트의 props에 연결하는 건 못하겠어서 `<Cell {...row as Attributes & T} />`로 하여 props를 T(제네릭)로 type assertion하였습니다.
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->