### PR TITLE
[ Fix ] 5차 QA 수정

### DIFF
--- a/src/app/api/auth/actions.ts
+++ b/src/app/api/auth/actions.ts
@@ -39,7 +39,7 @@ export const loginAction = async (values: z.infer<typeof loginSchema>) => {
             message: error.cause?.err?.message,
             msg: (await (
               error.cause?.err as HTTPError
-            ).response.json()) as APIError,
+            ).response?.json()) as APIError,
             type: error.type,
           };
         }

--- a/src/app/api/auth/callback/github/route.ts
+++ b/src/app/api/auth/callback/github/route.ts
@@ -1,4 +1,3 @@
-// app/api/auth/callback/custom-oauth/route.ts
 import { kyJsonInstance } from "@/app/api";
 import { getMyInfo } from "@/app/api/users";
 import { signIn } from "@/auth";

--- a/src/app/api/index.ts
+++ b/src/app/api/index.ts
@@ -1,13 +1,20 @@
 import { auth, signOut } from "@/auth";
-import { HTTP_ERROR_STATUS } from "@/shared/constant/api";
+import { HTTP_ERROR_STATUS, NO_RETRY_STATUSES } from "@/shared/constant/api";
+import { logError } from "@/shared/util/error";
 import { getAccessToken, setAccessToken } from "@/shared/util/token";
 import { isServer } from "@tanstack/react-query";
-import type { BeforeRetryHook, HTTPError, KyRequest } from "ky";
+import type {
+  AfterResponseHook,
+  BeforeRetryHook,
+  HTTPError,
+  KyRequest,
+} from "ky";
 import ky from "ky";
 import { signOut as cSignOut, getSession } from "next-auth/react";
 import { IS_PROD } from "../config";
 import { reIssueAction } from "./auth/actions";
 
+// beforeRequest
 const insertToken = async (request: KyRequest) => {
   const isServer = typeof window === "undefined";
   let accessToken = isServer ? (await auth())?.accessToken : getAccessToken();
@@ -19,6 +26,8 @@ const insertToken = async (request: KyRequest) => {
 
   request.headers.set("Authorization", `Bearer ${accessToken}`);
 };
+
+// beforeRetry
 const insertNewToken: BeforeRetryHook = async ({
   error,
   request,
@@ -38,20 +47,47 @@ const insertNewToken: BeforeRetryHook = async ({
     request.headers.set("Authorization", `Bearer ${newAccessToken}`);
   }
 };
+const handleAbortRetryError: BeforeRetryHook = async ({ request }) => {
+  if (request.headers.get("AbortRetryError")) {
+    throw new Error("AbortRetryError");
+  }
+};
+
+const handleErrorResponse: AfterResponseHook = async (
+  request,
+  _option,
+  response,
+) => {
+  const status = response.status;
+  const shouldRetry = !NO_RETRY_STATUSES.includes(status);
+
+  if (!response.ok) {
+    const clonedResponse = response.clone();
+    const errorData = (await clonedResponse.json())?.error;
+
+    logError({
+      request,
+      status,
+      errorData,
+    });
+    if (!shouldRetry) request.headers.append("AbortRetryError", "true");
+  }
+  return response;
+};
 const RETRY = 2;
 
 const prefixUrl = IS_PROD
   ? process.env.NEXT_PUBLIC_HOST
   : process.env.NEXT_PUBLIC_RC_HOST;
 
-if (isServer) {
-  console.log({ prefixUrl });
-  console.log(process.env);
-}
 export const kyJsonInstance = ky.create({
   prefixUrl,
   headers: {
     "Content-Type": "application/json",
+  },
+  hooks: {
+    beforeRetry: [handleAbortRetryError],
+    afterResponse: [handleErrorResponse],
   },
 });
 
@@ -62,20 +98,26 @@ export const kyJsonWithTokenInstance = ky.create({
   },
   hooks: {
     beforeRequest: [insertToken],
-    beforeRetry: [insertNewToken],
+    beforeRetry: [handleAbortRetryError, insertNewToken],
+    afterResponse: [handleErrorResponse],
   },
   retry: RETRY,
 });
 
 export const kyFormInstance = ky.create({
   prefixUrl,
+  hooks: {
+    beforeRetry: [handleAbortRetryError],
+    afterResponse: [handleErrorResponse],
+  },
 });
 
 export const kyFormWithTokenInstance = ky.create({
   prefixUrl,
   hooks: {
     beforeRequest: [insertToken],
-    beforeRetry: [insertNewToken],
+    beforeRetry: [handleAbortRetryError, insertNewToken],
+    afterResponse: [handleErrorResponse],
   },
   retry: RETRY,
 });

--- a/src/app/group/[groupId]/notice/query.ts
+++ b/src/app/group/[groupId]/notice/query.ts
@@ -37,8 +37,8 @@ export const useNoticeMutation = (groupId: number) => {
   return useMutation({
     mutationFn: (requestData: NoticeRequest) =>
       noticeAction(groupId, requestData),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["notices", groupId],
       });
       router.push(`/group/${groupId}/notice`);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -65,5 +65,8 @@ export const {
     },
   },
   session: { strategy: "jwt" },
+  logger: {
+    error: () => {},
+  },
   ...authConfig,
 });

--- a/src/common/component/Calendar/index.tsx
+++ b/src/common/component/Calendar/index.tsx
@@ -43,6 +43,12 @@ const Calendar = forwardRef<DatePicker, CalendarProps>(
       }
     };
 
+    // 820px 이상일 때 아래에 표시
+    const popperPlacement =
+      document?.documentElement?.clientHeight > 820
+        ? "bottom-start"
+        : "top-start";
+
     return (
       <div className={wrapperStyle}>
         <DatePicker
@@ -54,7 +60,7 @@ const Calendar = forwardRef<DatePicker, CalendarProps>(
           onChange={handleDateChange}
           locale="ko"
           calendarStartDay={1}
-          popperPlacement="bottom-start"
+          popperPlacement={popperPlacement}
           shouldCloseOnSelect
           popperProps={{ strategy: "fixed" }}
           popperModifiers={[

--- a/src/shared/component/Form/index.css.ts
+++ b/src/shared/component/Form/index.css.ts
@@ -103,8 +103,6 @@ export const itemDefaultStyle = style({
   display: "flex",
   flexDirection: "column",
   gap: ".5rem",
-
-  width: "100%",
 });
 
 export const errorLabelStyle = style({

--- a/src/shared/component/Form/index.tsx
+++ b/src/shared/component/Form/index.tsx
@@ -28,6 +28,7 @@ type FormFieldProps<
   showDescription?: boolean;
   revalidationHandlers?: typeof handleOnChangeMode;
   form: UseFormReturn<TFieldValues>;
+  wrapperProps?: ComponentProps<"div">;
   labelProps?: ComponentProps<typeof FormLabel>;
   descriptionProps?: ComponentProps<typeof FormDescription>;
 } & (
@@ -49,6 +50,7 @@ const FormController = <
   showDescription = false,
   revalidationHandlers,
   form,
+  wrapperProps,
   labelProps,
   fieldProps,
   descriptionProps,
@@ -112,7 +114,10 @@ const FormController = <
           );
         }
         return (
-          <div className={clsx(itemDefaultStyle)}>
+          <div
+            {...wrapperProps}
+            className={clsx(itemDefaultStyle, wrapperProps?.className)}
+          >
             {showDescription && descriptionPosition === "top" && Description}
 
             {showLabel && labelPosition === "top" && (

--- a/src/shared/constant/api.ts
+++ b/src/shared/constant/api.ts
@@ -8,3 +8,5 @@ export const HTTP_ERROR_STATUS = {
   GONE: 410,
   INTERNAL_SERVER_ERROR: 500,
 } as const;
+
+export const NO_RETRY_STATUSES = Object.values(HTTP_ERROR_STATUS) as number[];

--- a/src/shared/util/error.ts
+++ b/src/shared/util/error.ts
@@ -1,3 +1,11 @@
+import type { KyRequest } from "ky";
+
+interface ErrorLogParams {
+  request: KyRequest;
+  status: number;
+  errorData: string;
+}
+
 export const isHTTPError = (
   error: unknown,
 ): error is { response: { status: number } } => {
@@ -9,4 +17,53 @@ export const isHTTPError = (
     typeof error.response === "object" &&
     "status" in error.response
   );
+};
+
+const NODE_COLORS = {
+  reset: "\x1b[0m", // 색 설정 초기화
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+  bgRed: "\x1b[41m",
+};
+
+const styles = {
+  header:
+    "color: #721c24; background-color: #f8d7da; padding: 2px 4px; border-radius: 3px;",
+  method: "color: #0f5132; background-color: #d1e7dd; padding: 2px 4px;",
+  path: "color: #084298; background-color: #cfe2ff; padding: 2px 4px;",
+  status: `color: white; background-color: "#dc3545"; padding: 2px 4px;`,
+  error: "color: #664d03; background-color: #fff3cd; padding: 2px 4px;",
+};
+
+const isNode = typeof window === "undefined";
+
+export const logError = ({
+  request,
+  status,
+  errorData,
+}: ErrorLogParams): void => {
+  const urlPath = new URL(request.url).pathname;
+
+  if (isNode) {
+    console.warn(
+      `${NODE_COLORS.bgRed}🚨 API ERROR ${NODE_COLORS.reset}\n` +
+        `${NODE_COLORS.green}${request.method.padEnd(7)} ${urlPath}${NODE_COLORS.reset}\n` +
+        `${NODE_COLORS.magenta}STATUS: ${status}${NODE_COLORS.reset}\n` +
+        `${NODE_COLORS.yellow}ERROR: ${errorData}${NODE_COLORS.reset}`,
+    );
+  } else {
+    console.warn(
+      `%c🚨 API Error\n%c${request.method.padEnd(7)}%c${urlPath}\n%cSTATUS: ${status}\n%cERROR: %O`,
+      styles.header,
+      styles.method,
+      styles.path,
+      styles.status,
+      styles.error,
+      errorData,
+    );
+  }
 };

--- a/src/shared/util/time.ts
+++ b/src/shared/util/time.ts
@@ -47,5 +47,5 @@ export const getNextMidnight = () => {
   const now = new Date();
   now.setDate(now.getDate() + 1);
   now.setHours(0, 0, 0, 0);
-  return now;
+  return now.getTime();
 };

--- a/src/view/group/setting/SettingSidebar/index.tsx
+++ b/src/view/group/setting/SettingSidebar/index.tsx
@@ -63,8 +63,8 @@ const SettingSidebar = ({ info, code }: SettingSidebarProps) => {
   const error = form.formState.errors.endDate;
 
   const isSubmittable =
-    form.formState.isDirty &&
     form.formState.isValid &&
+    form.formState.isDirty &&
     !form.formState.isSubmitted;
 
   return (

--- a/src/view/signup/EmailVerification/index.tsx
+++ b/src/view/signup/EmailVerification/index.tsx
@@ -40,10 +40,12 @@ const EmailVerification = () => {
             name="email"
             type="input"
             showDescription
+            wrapperProps={{
+              style: { width: "100%" },
+            }}
             fieldProps={{
               placeholder: "이메일을 입력해주세요",
               size: "large",
-              style: { width: "100%" },
             }}
           />
           <Button

--- a/src/view/user/index/ExtensionAlertModal.tsx
+++ b/src/view/user/index/ExtensionAlertModal.tsx
@@ -31,9 +31,13 @@ const ExtensionAlertModalController = ({
     );
 
     if (isAuth && !isInstalled) {
-      const extensionAlertDate = localStorage.getItem(key);
-      const isNextDate = extensionAlertDate
-        ? Date.now() < +extensionAlertDate
+      const storedDate = localStorage.getItem(key);
+      const parsedStoredDate = storedDate
+        ? Number.parseInt(storedDate, 10)
+        : null;
+
+      const isNextDate = parsedStoredDate
+        ? Date.now() < parsedStoredDate
         : false;
       if (!isNextDate) setIsOpen(true);
     }

--- a/src/view/user/setting/MyProfile/EditForm/schema.ts
+++ b/src/view/user/setting/MyProfile/EditForm/schema.ts
@@ -8,11 +8,5 @@ export const baseEditSchema = z.object({
     .max(16)
     .regex(/^[a-zA-Z가-하0-9]+$/, "닉네임을 입력해주세요."),
 
-  bjNickname: z
-    .string()
-    .min(4, { message: "백준 아이디를 확인해주세요" })
-    .max(20, { message: "백준 아이디를 확인해주세요" })
-    .regex(/^[a-zA-Z0-9_]+$/, "백준 아이디를 확인해주세요"),
-
   description: z.string(),
 });

--- a/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
+++ b/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
@@ -18,7 +18,6 @@ const useEditForm = () => {
     defaultValues: {
       profileImage: user?.profileImage || null,
       nickname: user?.nickname,
-      bjNickname: user?.bjNickname,
       description: user?.description,
     },
   });


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #385 #337 
close fe-29
close fe-30

## ✅ Done Task
  - [x] Next서버 log 캐치 및 스타일 적용
  - [x] 마이페이지 및 그룹페이지 sidebar의 프로필 이미지 배치 수정 (중앙 정렬)
  - [x] 그룹페이지 스터디 수정 시 사진만 수정할 경우 수정 활성화 안되는 버그 수정
  - [x] datePicker 등장 위치 로직 세분화
  - [x] 공지 글쓰기 api 잘못 작성한 코드 수정
  - [x] 내 프로필 수정 시 버튼 활성화 안되는 버그 수정
  - [x] 익스텐션 설치 안내 모달 등장 로직 보강 (모달이 계속 나오는 디바이스에서 디버깅 및 확인 필요)

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
1. 콘솔을 디자인하는 방법입니다.
    ```typescript
    console.warn(
      `${NODE_COLORS.bgRed}🚨 API ERROR ${NODE_COLORS.reset}\n` +
        `${NODE_COLORS.green}${request.method.padEnd(7)} ${urlPath}${NODE_COLORS.reset}\n` +
        `${NODE_COLORS.magenta}STATUS: ${status}${NODE_COLORS.reset}\n` +
        `${NODE_COLORS.yellow}ERROR: ${errorData}${NODE_COLORS.reset}`,
    );
    console.warn(
          `%c🚨 API Error\n%c${request.method.padEnd(7)}%c${urlPath}\n%cSTATUS: ${status}\n%cERROR: %O`,
          styles.header,
          styles.method,
          styles.path,
          styles.status,
          styles.error,
          errorData,
        );
    ```
    항상 백틱으로 문자열을 작성하고, 윈도우나 우분투 콘솔이면 `cyan: "\x1b[36m", bgRed: "\x1b[41m"` 이런 식의 색상 값을, 브라우저는 `%c`와 함께 css 문법을 사용합니다. `%O`로 문자열 값을 넣을 수도 있습니다.

2. 사진만 수정하면 활성화 안되는 이유
   react-form-hook의 formState에 들어있는 속성들은 성능을 위해 proxy로 감싸져 있어 값에 접근하지 않으면 계산을 하지 않는다고 했었습니다(#286).

3. date picker 등장 위치
  date picker가 화면에 잘리게 나올 경우 반대 방향(위)으로 나오게 하는 기능이 있었습니다. 간단하게, 열었을 때 잘리는 화면 크기면 기본적으로 위로 열리도록 수정했습니다. (기존에 아래로 열리게 한 이유는 달을 바꿀 때마다 화살표 위치가 도망가기 때문에 불편..)

4. 공지 글 쓰기 로직
  비동기 함수인데 async await을 안 써서 그랬던 겁니다.

5. 내 프로필 수정 시 버튼 활성화 안되던 버그
  백준 닉네임이 다른 곳으로 가서 안 쓰이는데 schema에는 남겨 놓는 바람에 에러는 안 뜨고 valid만 false인 진풍경이 벌어졌었습니다.

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
1. 익스텐션 설치 안내 모달
  맥에서만 발생하는 것 같은데 누군가 디버깅 좀 부탁드림~
  시간 확인하는 로직이 잘 작동하는지 봐주시면 됩니다.
2. [회원가입 위해 이메일 인증시 인증url 거부당함](https://www.notion.so/url-1bfa3e66502e80dca8d4e398423660f2?pvs=21)
  redirect url이 sign-up으로 돼있어서 프론트의 singup/page.tsx에 작성한 token받아오는 로직을 못 쓰고 있습니다.
  (서버 측 문제)
3. 이미지 수정이 안되는 버그
  이것저것 확인해봤는데 스웨거에서도 안되는 걸 보면 서버 코드 문제인가 봅니다.
  클라 문제는 없었고, 서버 로그만 봤을 땐 스프링이 이미지를 안받더라구요!
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
next서버 에러 로그는 이렇게 뜹니다. 사진 맨 밑에 next-auth 에러 텍스트는 보기 힘들게 만들기만 해서 없앴습니다.

![image](https://github.com/user-attachments/assets/c18cd5fb-e103-4e5e-a5a8-4f824e896d06)
