### PR TITLE
[ Fix ] 문제 추가 시 탭 자동 변경 및 mutation 코드 수정

### DIFF
--- a/src/app/[user]/setting/query.ts
+++ b/src/app/[user]/setting/query.ts
@@ -83,9 +83,11 @@ export const useBookmarkGroupMutation = () => {
         }
       }
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["groupsSetting"] });
-      queryClient.invalidateQueries({ queryKey: ["myGroups"] });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["groupsSetting"] }),
+        queryClient.invalidateQueries({ queryKey: ["myGroups"] }),
+      ]);
       showToast("정상적으로 수정되었습니다.", "success");
     },
   });
@@ -119,8 +121,8 @@ export const useVisibilityMutation = () => {
 
       return { prevData };
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["groupsSetting"] });
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["groupsSetting"] });
     },
     onError: (error: HTTPError, _newData, context) => {
       queryClient.setQueryData(["groupsSetting"], context?.prevData);
@@ -179,8 +181,8 @@ export const useNotificationSettingMutation = () => {
 
       return { prevData };
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["notificationsSetting"],
       });
       showToast("정상적으로 수정되었습니다.", "success");

--- a/src/app/api/index.ts
+++ b/src/app/api/index.ts
@@ -47,8 +47,11 @@ const insertNewToken: BeforeRetryHook = async ({
     request.headers.set("Authorization", `Bearer ${newAccessToken}`);
   }
 };
-const handleAbortRetryError: BeforeRetryHook = async ({ request }) => {
-  if (request.headers.get("AbortRetryError")) {
+const handleAbortRetryError: BeforeRetryHook = async ({
+  request,
+  retryCount,
+}) => {
+  if (retryCount === 2 && request.headers.get("AbortRetryError")) {
     throw new Error("AbortRetryError");
   }
 };
@@ -98,8 +101,7 @@ export const kyJsonWithTokenInstance = ky.create({
   },
   hooks: {
     beforeRequest: [insertToken],
-    beforeRetry: [handleAbortRetryError, insertNewToken],
-    afterResponse: [handleErrorResponse],
+    beforeRetry: [insertNewToken],
   },
   retry: RETRY,
 });
@@ -116,8 +118,7 @@ export const kyFormWithTokenInstance = ky.create({
   prefixUrl,
   hooks: {
     beforeRequest: [insertToken],
-    beforeRetry: [handleAbortRetryError, insertNewToken],
-    afterResponse: [handleErrorResponse],
+    beforeRetry: [insertNewToken],
   },
   retry: RETRY,
 });

--- a/src/app/group/[groupId]/notice/query.ts
+++ b/src/app/group/[groupId]/notice/query.ts
@@ -53,8 +53,8 @@ export const usePatchNoticeMutation = (noticeId: number) => {
   return useMutation({
     mutationFn: (requestData: NoticeRequest) =>
       patchNoticeAction(noticeId, requestData),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["notice", noticeId],
       });
       showToast("정상적으로 수정되었어요.", "success");
@@ -71,8 +71,8 @@ export const useDeleteNoticeMutation = (groupId: number, noticeId: number) => {
 
   return useMutation({
     mutationFn: () => deleteNoticeAction(noticeId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["notices", groupId],
       });
       showToast("정상적으로 삭제되었어요.", "success");

--- a/src/app/group/[groupId]/problem-list/page.tsx
+++ b/src/app/group/[groupId]/problem-list/page.tsx
@@ -35,7 +35,7 @@ const ProblemListPage = ({
   } = usePaginationQuery({
     queryKey: [
       "inProgressProblem",
-      groupId,
+      +groupId,
       { unsolved: isUnsolvedOnlyChecked },
     ],
     queryFn: (page) =>
@@ -54,7 +54,7 @@ const ProblemListPage = ({
     totalPages: expiredTotalPages,
     setCurrentPage: setExpiredPage,
   } = usePaginationQuery({
-    queryKey: ["expiredProblem", groupId],
+    queryKey: ["expiredProblem", +groupId],
     queryFn: (page) =>
       getExpiredProblems({
         groupId: +groupId,

--- a/src/app/group/[groupId]/problem-list/query.ts
+++ b/src/app/group/[groupId]/problem-list/query.ts
@@ -24,15 +24,18 @@ export const usePostProblemMutation = (groupId: number) => {
     onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["inProgressProblem", groupId.toString()],
+          queryKey: ["inProgressProblem", groupId],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["queuedProblem", groupId.toString()],
+          queryKey: ["queuedProblem", groupId],
         }),
       ]);
-      if (+variables.startDate >= Date.now()) {
-        (document.querySelector("#tab-2") as HTMLLIElement)?.click();
-      }
+      (
+        document.querySelector(
+          +variables.startDate < Date.now() ? "#tab-1" : "#tab-2",
+        ) as HTMLLIElement
+      )?.click();
+
       showToast("문제가 정상적으로 등록되었어요.", "success");
     },
     onError: (error: Error) => {
@@ -53,10 +56,10 @@ export const useDeleteProblemMutation = (groupId: number) => {
           queryKey: ["deleteProblem"],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["queuedProblem", groupId.toString()],
+          queryKey: ["queuedProblem", groupId],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["inProgressProblem", groupId.toString()],
+          queryKey: ["inProgressProblem", groupId],
         }),
       ]);
       showToast("문제가 삭제되었습니다.", "success");

--- a/src/app/group/[groupId]/problem-list/query.ts
+++ b/src/app/group/[groupId]/problem-list/query.ts
@@ -24,10 +24,10 @@ export const usePostProblemMutation = (groupId: number) => {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["inProgressProblem", groupId, 0],
+          queryKey: ["inProgressProblem", groupId],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["queuedProblem", groupId, 0],
+          queryKey: ["queuedProblem", groupId],
         }),
       ]);
       showToast("문제가 정상적으로 등록되었어요.", "success");
@@ -50,10 +50,10 @@ export const useDeleteProblemMutation = (groupId: number) => {
           queryKey: ["deleteProblem"],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["queuedProblem", groupId, 0],
+          queryKey: ["queuedProblem", groupId],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["inProgressProblem", groupId, 0],
+          queryKey: ["inProgressProblem", groupId],
         }),
       ]);
       showToast("문제가 삭제되었습니다.", "success");
@@ -81,10 +81,10 @@ export const usePatchProblemMutation = (groupId: number, problemId: number) => {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["queuedProblem", groupId, 0],
+          queryKey: ["queuedProblem", groupId],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["inProgressProblem", groupId, 0],
+          queryKey: ["inProgressProblem", groupId],
         }),
       ]);
       showToast("문제가 정상적으로 수정되었어요.", "success");

--- a/src/app/group/[groupId]/problem-list/query.ts
+++ b/src/app/group/[groupId]/problem-list/query.ts
@@ -24,10 +24,10 @@ export const usePostProblemMutation = (groupId: number) => {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["inProgressProblem", groupId],
+          queryKey: ["inProgressProblem", groupId.toString()],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["queuedProblem", groupId],
+          queryKey: ["queuedProblem", groupId.toString()],
         }),
       ]);
       showToast("문제가 정상적으로 등록되었어요.", "success");
@@ -50,10 +50,10 @@ export const useDeleteProblemMutation = (groupId: number) => {
           queryKey: ["deleteProblem"],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["queuedProblem", groupId],
+          queryKey: ["queuedProblem", groupId.toString()],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["inProgressProblem", groupId],
+          queryKey: ["inProgressProblem", groupId.toString()],
         }),
       ]);
       showToast("문제가 삭제되었습니다.", "success");

--- a/src/app/group/[groupId]/problem-list/query.ts
+++ b/src/app/group/[groupId]/problem-list/query.ts
@@ -21,13 +21,15 @@ export const usePostProblemMutation = (groupId: number) => {
       endDate,
     }: Omit<problemActionRequest, "groupId">) =>
       postProblemAction({ groupId, link, startDate, endDate }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["inProgressProblem", groupId, 0],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["queuedProblem", groupId, 0],
-      });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["inProgressProblem", groupId, 0],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["queuedProblem", groupId, 0],
+        }),
+      ]);
       showToast("문제가 정상적으로 등록되었어요.", "success");
     },
     onError: (error: Error) => {
@@ -42,17 +44,18 @@ export const useDeleteProblemMutation = (groupId: number) => {
 
   return useMutation({
     mutationFn: (problemId: number) => deleteProblem(problemId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["deleteProblem"],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["queuedProblem", groupId, 0],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["inProgressProblem", groupId, 0],
-      });
-
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["deleteProblem"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["queuedProblem", groupId, 0],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["inProgressProblem", groupId, 0],
+        }),
+      ]);
       showToast("문제가 삭제되었습니다.", "success");
     },
     onError: () => {
@@ -75,13 +78,15 @@ export const usePatchProblemMutation = (groupId: number, problemId: number) => {
   return useMutation({
     mutationFn: ({ startDate, endDate }: EditProblemRequest) =>
       patchProblem({ problemId, startDate, endDate }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["queuedProblem", groupId, 0],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["inProgressProblem", groupId, 0],
-      });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["queuedProblem", groupId, 0],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["inProgressProblem", groupId, 0],
+        }),
+      ]);
       showToast("문제가 정상적으로 수정되었어요.", "success");
     },
     onError: () => {

--- a/src/app/group/[groupId]/problem-list/query.ts
+++ b/src/app/group/[groupId]/problem-list/query.ts
@@ -21,7 +21,7 @@ export const usePostProblemMutation = (groupId: number) => {
       endDate,
     }: Omit<problemActionRequest, "groupId">) =>
       postProblemAction({ groupId, link, startDate, endDate }),
-    onSuccess: async () => {
+    onSuccess: async (_, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: ["inProgressProblem", groupId.toString()],
@@ -30,6 +30,9 @@ export const usePostProblemMutation = (groupId: number) => {
           queryKey: ["queuedProblem", groupId.toString()],
         }),
       ]);
+      if (+variables.startDate >= Date.now()) {
+        (document.querySelector("#tab-2") as HTMLLIElement)?.click();
+      }
       showToast("문제가 정상적으로 등록되었어요.", "success");
     },
     onError: (error: Error) => {

--- a/src/app/group/[groupId]/setting/query.ts
+++ b/src/app/group/[groupId]/setting/query.ts
@@ -32,11 +32,10 @@ export const useDeleteMemberMutation = (groupId: number) => {
   return useMutation({
     mutationFn: ({ memberId }: { memberId: number }) =>
       deleteGroupMember(memberId, groupId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["memberList", groupId],
       });
-
       showToast("멤버가 정상적으로 삭제되었어요.", "success");
     },
     onError: () => {
@@ -53,8 +52,8 @@ export const useDeleteGroupMutation = () => {
 
   return useMutation({
     mutationFn: (groupId: number) => deleteGroup(groupId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["groups", "setting"],
       });
       showToast("그룹이 정상적으로 삭제되었어요.", "success");
@@ -75,8 +74,8 @@ export const usePatchGroupMutation = (groupId: number) => {
 
   return useMutation({
     mutationFn: (formData: FormData) => editGroup(groupId, formData),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["deleteGroup", groupId],
       });
       showToast("정상적으로 수정되었어요.", "success");
@@ -110,8 +109,8 @@ export const usePatchMemberRoleMutation = (groupId: number) => {
 
   return useMutation({
     mutationFn: (request: MemberRoleRequest) => editRole(groupId, request),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({
         queryKey: ["memberList", groupId],
       });
       showToast("정상적으로 수정되었어요.", "success");

--- a/src/app/group/[groupId]/solved-detail/[id]/query.ts
+++ b/src/app/group/[groupId]/solved-detail/[id]/query.ts
@@ -29,8 +29,8 @@ export const useCommentMutataion = (solutionId: number) => {
 
   return useMutation({
     mutationFn: (content: string) => commentAction(solutionId, content),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["solution", "comment", solutionId],
       });
     },
@@ -47,8 +47,8 @@ export const useDeleteCommentMutation = (solutionId: number) => {
 
   return useMutation({
     mutationFn: (commentId: number) => deleteComment(commentId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["solution", "comment", solutionId],
       });
     },
@@ -74,8 +74,8 @@ export const useEditCommentMutation = (
 
   return useMutation({
     mutationFn: (content: string) => editComment(commentId, content),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["solution", "comment", solutionId],
       });
     },

--- a/src/app/query.ts
+++ b/src/app/query.ts
@@ -38,8 +38,8 @@ export const useReadNotiItemMutation = () => {
 
       return { prev };
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["notifications"] });
     },
     onError: (_err, _new, context) => {
       queryClient.setQueryData(["notifications"], context?.prev);
@@ -64,8 +64,8 @@ export const useReadAllNotiMutation = () => {
 
       return { prev };
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["notifications"] });
     },
     onError: (_err, _new, context) => {
       queryClient.setQueryData(["notifications"], context?.prev);

--- a/src/common/component/Carousel/index.css.ts
+++ b/src/common/component/Carousel/index.css.ts
@@ -94,10 +94,6 @@ export const sliderWrapperStyle = style({
 export const itemStyle = style({
   display: "flex",
   justifyContent: "center",
-
-  width: "calc(25% - 1.5rem)",
-  minWidth: "25rem",
-  maxWidth: "30rem",
   height: "100%",
 
   overflow: "hidden",

--- a/src/shared/component/Header/Notification/index.tsx
+++ b/src/shared/component/Header/Notification/index.tsx
@@ -45,11 +45,11 @@ const Notification = ({ notificationList, ...props }: NotificationProps) => {
 
   const handleItemDelete = (notificationId: number) => {
     deleteMutate(notificationId, {
-      onSuccess: () => {
+      onSuccess: async () => {
         setNotifications((prev) =>
           prev.filter((item) => item.id !== notificationId),
         );
-        queryClient.invalidateQueries({
+        await queryClient.invalidateQueries({
           queryKey: ["notifications"],
         });
       },

--- a/src/shared/component/WithdrawDialog/query.ts
+++ b/src/shared/component/WithdrawDialog/query.ts
@@ -9,11 +9,10 @@ export const useWithdrawMutation = () => {
 
   return useMutation({
     mutationFn: (groupId: number) => withdrawGroup(groupId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["groupsSetting"],
       });
-
       showToast("정상적으로 탈퇴되었어요.", "success");
     },
     onError: (error: HTTPError) => {

--- a/src/view/group/dashboard/NoticeModal/NoticeDetail/query.ts
+++ b/src/view/group/dashboard/NoticeModal/NoticeDetail/query.ts
@@ -21,8 +21,8 @@ export const useNoticeCommentMutation = (noticeId: number) => {
 
   return useMutation({
     mutationFn: (content: string) => postNoticeComment(noticeId, content),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["notice", "comment", noticeId],
       });
     },
@@ -36,8 +36,8 @@ export const useDeleteNoticeCommentMutation = (noticeId: number) => {
 
   return useMutation({
     mutationFn: (commentId: number) => deleteNoticeComment(commentId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["notice", "comment", noticeId],
       });
     },
@@ -63,8 +63,8 @@ export const useEditNoticeCommentMutation = (
 
   return useMutation({
     mutationFn: (content: string) => patchNoticeComment(commentId, content),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: ["notice", "comment", noticeId],
       });
     },


### PR DESCRIPTION
## ✅ Done Task
  - [x] 문제 추가 시 해당 탭으로 자동변경
  - [x] 문제 CRUD하면 바로 반영되게 수정(기존엔 새로고침 필요)
  - [x] 과잉 적용한 재시도 방어로직 제거
  - [x] 유저페이지 그룹 카드 간격 줄이기
  - close FE-36 FE-42
## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
문제리스트 query의 모든 `invalidateQueries`에 async await이 없더군요. 그래서 추가했습니다.

또한 `page.tsx`의 params로 얻어온 값은 string이고 이걸로 `queryKey`를 구성하는데 `invalidateQueries`를 할 key는 number 타입이라 제대로 refetch하지 못하고 있었어서 `queryKey` 구성 때 number로 형 변환해서 쓰도록 수정했습니다.

탭 자동변경 기능의 경우 `Sidebar`와 `Tab`이 아예 다른 위치의 컴포넌트다 보니 `Context Api`로 만들어진 `Tab` 컴포넌트 훅을 못 쓰는 상황입니다. 그래서 작업 환경 상 부득이하게 `querySelector`로 직접 `Tab`을 조작하는 간단하고 쉬운 방법을 사용했습니다.
옳은 해결법은 탭 조작 훅을 `context`대신 `jotai`로 바꾸고 `Tab`을 만들때마다 atom을 새로 만들어 쓰는 로직(Tab들이 같은 atom을 쓰면 안되니까요)도 포함하는 것 입니다.

마지막으로 토큰을 사용하는 ky instance에 쓸데없이 retry 방지 로직을 적용했었음을 깨닫고 지웠습니다. 인증 토큰 교체까지 방어하더라구요.
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->