### PR TITLE
[ Fix ] SolutionList 데이터 캐싱 문제

### DIFF
--- a/src/app/api/users/index.ts
+++ b/src/app/api/users/index.ts
@@ -131,13 +131,9 @@ export const getExpiredMySolutions = async ({
   return response;
 };
 
-export const deleteMe = async ({
-  isOAuthAccount = false,
-  password,
-}: DeleteUserRequest) => {
+export const deleteMe = async ({ password }: DeleteUserRequest) => {
   const response = await kyJsonWithTokenInstance.delete("api/users/me", {
     json: {
-      isOAuthAccount,
       password,
     },
   });

--- a/src/app/api/users/type.ts
+++ b/src/app/api/users/type.ts
@@ -3,7 +3,6 @@ export type CheckEmailRequest = {
 };
 
 export type DeleteUserRequest = {
-  isOAuthAccount?: boolean;
   password: string;
 };
 

--- a/src/app/api/users/type.ts
+++ b/src/app/api/users/type.ts
@@ -15,7 +15,8 @@ export type UserResponse = {
   email: string;
   nickname: string;
   profileImage?: string;
-  bjNickname: string;
+  bjNickname?: string;
+  githubName?: string;
   description?: string;
 };
 

--- a/src/app/group/[groupId]/problem-list/[id]/query.ts
+++ b/src/app/group/[groupId]/problem-list/[id]/query.ts
@@ -1,0 +1,35 @@
+import { getSolutionList } from "@/app/api/solutions";
+import type { SolutionLanguage } from "@/app/api/solutions/type";
+import { useDebounce } from "@/common/hook/useDebounce";
+import type { SolvedFilterType } from "@/shared/type/solvedFilter";
+import { useQuery } from "@tanstack/react-query";
+
+type useSolutionListQueryProps = {
+  problemId: number;
+  groupId: string;
+  option: SolvedFilterType;
+  nicknameFilter: string;
+};
+
+export const useSolutionListQuery = ({
+  problemId,
+  groupId,
+  option,
+  nicknameFilter,
+}: useSolutionListQueryProps) => {
+  const debouncedNicknameFilter = useDebounce(nicknameFilter, 200);
+
+  return useQuery({
+    queryKey: ["solution", problemId, groupId, option, debouncedNicknameFilter],
+    queryFn: () =>
+      getSolutionList({
+        problemId,
+        language:
+          option.language === "모든 언어"
+            ? undefined
+            : (option.language as SolutionLanguage),
+        result: option.result === "모든 결과" ? undefined : option.result,
+        nickname: debouncedNicknameFilter,
+      }),
+  });
+};

--- a/src/view/group/problem-list/SolvedList/index.tsx
+++ b/src/view/group/problem-list/SolvedList/index.tsx
@@ -1,9 +1,7 @@
 "use client";
 import type { ProblemContent } from "@/app/api/problems/type";
-import { getSolutionList } from "@/app/api/solutions";
-import type { SolutionLanguage } from "@/app/api/solutions/type";
+import { useSolutionListQuery } from "@/app/group/[groupId]/problem-list/[id]/query";
 import { IcnBtnArrowLeft } from "@/asset/svg";
-import { useDebounce } from "@/common/hook/useDebounce";
 import { handleA11yClick } from "@/common/util/dom";
 import SolvedFilterBar from "@/shared/component/SolvedFilterBar";
 import {
@@ -19,7 +17,6 @@ import {
   headerTextStyle,
   solvedListWrapper,
 } from "@/view/group/problem-list/SolvedList/index.css";
-import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -39,22 +36,14 @@ const initOption = {
 const SolvedList = ({ problemId, groupId, problemInfo }: SolvedListProps) => {
   const [option, setOption] = useState<SolvedFilterType>(initOption);
   const [nicknameFilter, setNicknameFilter] = useState("");
-  const debouncedNicknameFilter = useDebounce(nicknameFilter, 200);
 
   const router = useRouter();
 
-  const { data } = useQuery({
-    queryKey: ["solution", option, debouncedNicknameFilter],
-    queryFn: () =>
-      getSolutionList({
-        problemId,
-        language:
-          option.language === "모든 언어"
-            ? undefined
-            : (option.language as SolutionLanguage),
-        result: option.result === "모든 결과" ? undefined : option.result,
-        nickname: debouncedNicknameFilter,
-      }),
+  const { data } = useSolutionListQuery({
+    problemId,
+    groupId,
+    option,
+    nicknameFilter,
   });
 
   const handleChangeIdFilter = (value: string) => {


### PR DESCRIPTION
## ✅ Done Task
  - [x] SolutionList 쿼리키 추가
  - [x] SolutionList 쿼리 파일 분리
  - [x] 회원 정보 삭제 시, `isOAuthAccount` 필드 삭제(롤백)
  - [x] 회원 정보 조회 시, 'githubName' 필드 추가

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

`githubName` 필드 session에 추후 저장해야합니다!

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

### AS-IS

https://github.com/user-attachments/assets/cd2e65fd-fb9e-4c02-a8ba-0a2205893995

### TO-BE

https://github.com/user-attachments/assets/9d21ae49-d44c-4dd3-a743-e7ebed80d6eb

