### PR TITLE
[ Fix ] 문제 마우스 이벤트 정상화

### DIFF
--- a/src/shared/component/CommentBox/index.tsx
+++ b/src/shared/component/CommentBox/index.tsx
@@ -38,8 +38,7 @@ const CommentBox = ({
   className,
   isMine,
 }: CommentBoxProps) => {
-  const { isActive, handleFocus, handleBlur, handleMouseOver, handleMouseOut } =
-    useA11yHoverHandler();
+  const { isActive, ...handlers } = useA11yHoverHandler();
 
   const { register, control } = useEditForm(commentId, content);
 
@@ -52,10 +51,7 @@ const CommentBox = ({
 
   return (
     <li
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onMouseOver={handleMouseOver}
-      onMouseLeave={handleMouseOut}
+      {...handlers}
       aria-label={`코멘트 ${commentId}`}
       className={clsx(containerStyle({ isActive }), className)}
     >

--- a/src/shared/component/Header/Notification/NotificationItem.tsx
+++ b/src/shared/component/Header/Notification/NotificationItem.tsx
@@ -38,17 +38,13 @@ const NotificationListItem = ({
   isRead,
   onDelete,
 }: NotificationListProps) => {
-  const { isActive, handleMouseOver, handleMouseOut, handleFocus, handleBlur } =
-    useA11yHoverHandler();
+  const { isActive, ...handlers } = useA11yHoverHandler();
 
   return (
     <li
       className={containerStyle}
       aria-label={`${name}님의 알림: ${message}, ${date}`}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onMouseOver={handleMouseOver}
-      onMouseOut={handleMouseOut}
+      {...handlers}
     >
       <div
         role="button"

--- a/src/shared/component/ProblemList/Item.tsx
+++ b/src/shared/component/ProblemList/Item.tsx
@@ -18,11 +18,13 @@ import clsx from "clsx";
 
 import { format } from "date-fns";
 import Link from "next/link";
+import { useMemo } from "react";
 
 type ProblemListItemProps = Omit<ProblemContent, "startDate"> & {
   isOwner?: boolean;
   className?: string;
   isExpired?: boolean;
+  hasAnchor?: boolean;
 };
 
 const JSX_BY_STATUS = {
@@ -47,6 +49,7 @@ const ProblemListItem = ({
   accuracy,
   memberCount,
   submitMemberCount,
+  hasAnchor = false,
   isOwner = false,
   isExpired = false,
 }: ProblemListItemProps) => {
@@ -58,6 +61,21 @@ const ProblemListItem = ({
   const { isActive, handleBlur, handleFocus, handleMouseOut, handleMouseOver } =
     useA11yHoverHandler();
 
+  const Title = useMemo(
+    () =>
+      hasAnchor ? (
+        <span className={clsx(titleStyle, commonStyle)}>{title}</span>
+      ) : (
+        <Link
+          className={titleStyle}
+          href={`/group/${groupId}/problem-list/${problemId}`}
+        >
+          <span className={commonStyle}>{title}</span>
+        </Link>
+      ),
+    [hasAnchor],
+  );
+
   return (
     <li
       onFocus={handleFocus}
@@ -65,18 +83,10 @@ const ProblemListItem = ({
       onMouseOver={handleMouseOver}
       onMouseLeave={handleMouseOut}
       aria-label={`문제: ${title}`}
-      className={clsx(
-        itemStyle({ isActive: isOwner ? isActive : false }),
-        className,
-      )}
+      className={clsx(itemStyle({ isActive }), className)}
     >
       <Icon width={25} height={32} />
-      <Link
-        className={titleStyle}
-        href={`/group/${groupId}/problem-list/${problemId}`}
-      >
-        <span className={commonStyle}>{title}</span>
-      </Link>
+      {Title}
       <time dateTime={endDate} className={commonStyle}>
         {format(endDate, "yyyy.MM.dd")}
       </time>

--- a/src/shared/component/ProblemList/Item.tsx
+++ b/src/shared/component/ProblemList/Item.tsx
@@ -58,8 +58,7 @@ const ProblemListItem = ({
 
   const status = solved ? "solved" : isExpired ? "wrong" : "unsolved";
 
-  const { isActive, handleBlur, handleFocus, handleMouseOut, handleMouseOver } =
-    useA11yHoverHandler();
+  const { isActive, ...handlers } = useA11yHoverHandler();
 
   const Title = useMemo(
     () =>
@@ -78,10 +77,7 @@ const ProblemListItem = ({
 
   return (
     <li
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onMouseOver={handleMouseOver}
-      onMouseLeave={handleMouseOut}
+      {...handlers}
       aria-label={`문제: ${title}`}
       className={clsx(itemStyle({ isActive }), className)}
     >

--- a/src/shared/component/ProblemList/Item.tsx
+++ b/src/shared/component/ProblemList/Item.tsx
@@ -49,7 +49,7 @@ const ProblemListItem = ({
   accuracy,
   memberCount,
   submitMemberCount,
-  hasAnchor = false,
+  hasAnchor = true,
   isOwner = false,
   isExpired = false,
 }: ProblemListItemProps) => {
@@ -64,14 +64,14 @@ const ProblemListItem = ({
   const Title = useMemo(
     () =>
       hasAnchor ? (
-        <span className={clsx(titleStyle, commonStyle)}>{title}</span>
-      ) : (
         <Link
           className={titleStyle}
           href={`/group/${groupId}/problem-list/${problemId}`}
         >
           <span className={commonStyle}>{title}</span>
         </Link>
+      ) : (
+        <span className={clsx(titleStyle, commonStyle)}>{title}</span>
       ),
     [hasAnchor],
   );

--- a/src/shared/hook/useA11yHandler.ts
+++ b/src/shared/hook/useA11yHandler.ts
@@ -29,25 +29,25 @@ import { type FocusEvent, useState } from "react";
  */
 const useA11yHoverHandler = () => {
   const [isActive, setIsActive] = useState(false);
-  const handleFocus = (event: FocusEvent<HTMLElement | SVGElement>) => {
+  const onFocus = (event: FocusEvent<HTMLElement | SVGElement>) => {
     if (!event.currentTarget.contains(event.relatedTarget)) {
       setIsActive(true);
     }
   };
-  const handleBlur = (event: FocusEvent<HTMLElement | SVGElement>) => {
+  const onBlur = (event: FocusEvent<HTMLElement | SVGElement>) => {
     if (!event.currentTarget.contains(event.relatedTarget)) {
       setIsActive(false);
     }
   };
 
-  const handleMouseOver = () => {
+  const onMouseOver = () => {
     setIsActive(true);
   };
-  const handleMouseOut = () => {
+  const onMouseLeave = () => {
     setIsActive(false);
   };
 
-  return { isActive, handleFocus, handleBlur, handleMouseOver, handleMouseOut };
+  return { isActive, onFocus, onBlur, onMouseOver, onMouseLeave };
 };
 
 export default useA11yHoverHandler;

--- a/src/view/group/dashboard/NoticeModal/NoticeDetail/index.tsx
+++ b/src/view/group/dashboard/NoticeModal/NoticeDetail/index.tsx
@@ -43,8 +43,7 @@ const NoticeDetail = ({
   data: { author, title, createdAt, category, noticeId, content, isRead },
   goBack,
 }: NoticeDetailProps) => {
-  const { isActive, handleMouseOver, handleMouseOut, handleFocus, handleBlur } =
-    useA11yHoverHandler();
+  const { isActive, ...handlers } = useA11yHoverHandler();
 
   const [isEdit, setIsEdit] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -118,13 +117,7 @@ const NoticeDetail = ({
       </header>
 
       {/* 상세보기 내용 */}
-      <div
-        className={textareaWrapper}
-        onMouseOver={handleMouseOver}
-        onMouseOut={handleMouseOut}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-      >
+      <div className={textareaWrapper} {...handlers}>
         <Textarea
           ref={textareaRef}
           defaultValue={content}

--- a/src/view/group/my-solved/SolvedItem/index.css.ts
+++ b/src/view/group/my-solved/SolvedItem/index.css.ts
@@ -1,18 +1,28 @@
 import { theme } from "@/styles/themes.css";
 import { MYSOLVED_GRID_FRACTION } from "@/view/group/my-solved/constant";
 import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
 
-export const itemStyle = style({
-  display: "grid",
-  gridTemplateColumns: MYSOLVED_GRID_FRACTION,
-  alignItems: "center",
-  gap: "0.4rem",
+export const itemStyle = recipe({
+  base: {
+    display: "grid",
+    gridTemplateColumns: MYSOLVED_GRID_FRACTION,
+    alignItems: "center",
+    gap: "0.4rem",
 
-  width: "100%",
+    width: "100%",
 
-  padding: "0.5rem 2rem",
+    padding: "0.5rem 2rem",
 
-  cursor: "pointer",
+    cursor: "pointer",
+  },
+  variants: {
+    isActive: {
+      true: {
+        backgroundColor: "rgba(34, 39, 52, 1)",
+      },
+    },
+  },
 });
 
 export const textStyle = style({

--- a/src/view/group/my-solved/SolvedItem/index.tsx
+++ b/src/view/group/my-solved/SolvedItem/index.tsx
@@ -2,6 +2,7 @@
 
 import type { SolutionContent } from "@/app/api/solutions/type";
 import { IcnMessage, IcnMessageDot } from "@/asset/svg";
+import useA11yHoverHandler from "@/shared/hook/useA11yHandler";
 import useGetGroupId from "@/shared/hook/useGetGroupId";
 import { getFormattedMemory } from "@/shared/util/byte";
 import { getTierImage } from "@/shared/util/img";
@@ -30,6 +31,7 @@ const SolvedItem = ({ solutionInfo }: { solutionInfo: SolutionContent }) => {
   const LevelIcon = getTierImage(problemLevel);
 
   const router = useRouter();
+  const { isActive, ...handlers } = useA11yHoverHandler();
 
   const handleClickItem = () => {
     router.push(`/group/${groupId || pathGroupId}/solved-detail/${solutionId}`);
@@ -42,8 +44,9 @@ const SolvedItem = ({ solutionInfo }: { solutionInfo: SolutionContent }) => {
       tabIndex={0}
       onKeyDown={(e) => e.key === "Enter" && handleClickItem()}
       onClick={handleClickItem}
+      {...handlers}
       aria-label={`${problemLevel}: ${solutionId}`}
-      className={itemStyle}
+      className={itemStyle({ isActive })}
     >
       <div style={{ display: "flex", justifyContent: "center" }}>
         <LevelIcon width={25} height={32} />

--- a/src/view/group/my-solved/SolvedItem/index.tsx
+++ b/src/view/group/my-solved/SolvedItem/index.tsx
@@ -10,7 +10,6 @@ import {
   itemStyle,
   textStyle,
 } from "@/view/group/my-solved/SolvedItem/index.css";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 const SolvedItem = ({ solutionInfo }: { solutionInfo: SolutionContent }) => {
@@ -49,12 +48,9 @@ const SolvedItem = ({ solutionInfo }: { solutionInfo: SolutionContent }) => {
       <div style={{ display: "flex", justifyContent: "center" }}>
         <LevelIcon width={25} height={32} />
       </div>
-      <Link
-        className={textStyle}
-        href={`/group/${groupId}/problem-list/${solutionId}`}
-      >
-        {problemTitle}
-      </Link>
+
+      <span className={textStyle}>{problemTitle}</span>
+
       <time dateTime={solvedDateTime} className={textStyle}>
         {solvedDateTime}
       </time>

--- a/src/view/group/problem-list/PendingList/Item.tsx
+++ b/src/view/group/problem-list/PendingList/Item.tsx
@@ -33,15 +33,11 @@ const PendingListItem = ({
 }: PendingListItemProps) => {
   const Icon = getTierImage(level);
   const groupId = useGetGroupId();
-  const { isActive, handleBlur, handleFocus, handleMouseOut, handleMouseOver } =
-    useA11yHoverHandler();
+  const { isActive, ...handlers } = useA11yHoverHandler();
 
   return (
     <li
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onMouseOver={handleMouseOver}
-      onMouseLeave={handleMouseOut}
+      {...handlers}
       aria-label={`${level}: ${title}`}
       className={clsx(itemStyle, isActive && activeStyle, className)}
     >

--- a/src/view/group/problem-list/SolvedList/ProblemInfo.tsx
+++ b/src/view/group/problem-list/SolvedList/ProblemInfo.tsx
@@ -21,7 +21,7 @@ const ProblemInfo = ({ problemInfo }: ProblemInfoProps) => {
           submitMemberCount={problemInfo.submitMemberCount}
           accuracy={problemInfo.accuracy}
           link={problemInfo.link}
-          hasAnchor
+          hasAnchor={false}
         />
       </Link>
     </ProblemList>

--- a/src/view/group/problem-list/SolvedList/ProblemInfo.tsx
+++ b/src/view/group/problem-list/SolvedList/ProblemInfo.tsx
@@ -21,6 +21,7 @@ const ProblemInfo = ({ problemInfo }: ProblemInfoProps) => {
           submitMemberCount={problemInfo.submitMemberCount}
           accuracy={problemInfo.accuracy}
           link={problemInfo.link}
+          hasAnchor
         />
       </Link>
     </ProblemList>


### PR DESCRIPTION
## ✅ Done Task
  - [x] 문제 제목 부분에 클릭 이벤트 설정
  - [x] problem-list/[id], my-solved의 문제 리스트에 hover 이벤트 적용

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
문제 컴포넌트가 여러 곳에서 비슷한 형태로 쓰이다 보니 생긴 문제인 것 같습니다.
제목에만 링크가 있거나, 문제 컴포넌트를 감싸는 컴포넌트가 링크거나, 아예 버튼처럼 동작하게 하기 위해 링크를 안 쓰는 등등 의도에 맞게 내부 컴포넌트를 잘 바꿔주지 못한 부분들을 처리했습니다.

또한 예전에 얘기했던 `useA11yHoverHandler`의 속성 명을 on시리즈로 하여 {...handlers}로 줄여 사용할 수 있도록 변했습니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->