### PR TITLE
[ Feat ] OAuth 계정 여부 추가

### DIFF
--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -15,11 +15,13 @@ declare module "next-auth" {
     accessToken: string;
     refreshToken: string;
     accessTokenExpires: number;
+    isOAuthAccount: boolean;
   }
   interface User {
     nickname?: string;
     profileImage?: string;
     bjNickname?: string;
+    githubName?: string;
     description?: string;
     accessToken: string;
     refreshToken: string;

--- a/src/app/[user]/setting/query.ts
+++ b/src/app/[user]/setting/query.ts
@@ -14,7 +14,7 @@ import {
 } from "@/app/api/notifications";
 import type { NotificationSettingContent } from "@/app/api/notifications/type";
 import { deleteMe } from "@/app/api/users";
-import type { PasswordRequest } from "@/app/api/users/type";
+import type { DeleteUserRequest, PasswordRequest } from "@/app/api/users/type";
 import { useToast } from "@/common/hook/useToast";
 import { HTTP_ERROR_STATUS } from "@/shared/constant/api";
 import {
@@ -215,7 +215,8 @@ export const useDeleteMeMutation = () => {
   const { showToast } = useToast();
 
   return useMutation({
-    mutationFn: (password: string) => deleteMe({ password }),
+    mutationFn: ({ password, isOAuthAccount }: DeleteUserRequest) =>
+      deleteMe({ password, isOAuthAccount }),
     onSuccess: async () => {
       showToast("정상적으로 계정이 삭제되었습니다.", "success");
       await signOut({

--- a/src/app/api/users/index.ts
+++ b/src/app/api/users/index.ts
@@ -131,10 +131,14 @@ export const getExpiredMySolutions = async ({
   return response;
 };
 
-export const deleteMe = async ({ password }: DeleteUserRequest) => {
+export const deleteMe = async ({
+  password,
+  isOAuthAccount,
+}: DeleteUserRequest) => {
   const response = await kyJsonWithTokenInstance.delete("api/users/me", {
     json: {
       password,
+      isOAuthAccount,
     },
   });
 

--- a/src/app/api/users/type.ts
+++ b/src/app/api/users/type.ts
@@ -14,9 +14,9 @@ export type EditPasswordRequest = {
 export type UserResponse = {
   email: string;
   nickname: string;
-  profileImage?: string;
   bjNickname?: string;
   githubName?: string;
+  profileImage?: string;
   description?: string;
 };
 

--- a/src/app/api/users/type.ts
+++ b/src/app/api/users/type.ts
@@ -4,6 +4,7 @@ export type CheckEmailRequest = {
 
 export type DeleteUserRequest = {
   password: string;
+  isOAuthAccount: boolean;
 };
 
 export type EditPasswordRequest = {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -51,6 +51,7 @@ export const {
       session.accessToken = token.accessToken;
       session.refreshToken = token.refreshToken;
       session.accessTokenExpires = token.accessTokenExpires;
+      session.isOAuthAccount = !token.user.githubName;
       return session;
     },
   },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -51,7 +51,7 @@ export const {
       session.accessToken = token.accessToken;
       session.refreshToken = token.refreshToken;
       session.accessTokenExpires = token.accessTokenExpires;
-      session.isOAuthAccount = !token.user.githubName;
+      session.isOAuthAccount = !!token.user.githubName;
       return session;
     },
   },

--- a/src/view/login/LoginForm/index.tsx
+++ b/src/view/login/LoginForm/index.tsx
@@ -53,7 +53,7 @@ const LoginForm = () => {
           type="submit"
           size="medium"
           color="purple"
-          disabled={!isActive}
+          disabled={isPending || !isActive}
         >
           로그인
         </Button>

--- a/src/view/user/setting/AccountManagement/AccountManagementForm/index.tsx
+++ b/src/view/user/setting/AccountManagement/AccountManagementForm/index.tsx
@@ -53,47 +53,53 @@ const AccountManagementForm = () => {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleSubmit)} className={formStyle}>
-        <FormController
-          form={form}
-          name="currentPassword"
-          type="input"
-          showLabel
-          labelProps={{ children: "비밀번호 변경", className: labelStyle }}
-          fieldProps={{
-            placeholder: "기존 비밀번호",
-            className: width,
-            type: "password",
-          }}
-        />
-        <div className={passwordWrapper}>
-          <FormController
-            form={form}
-            type="input"
-            name="changePassword"
-            revalidationHandlers={getMultipleRevalidationHandlers(
-              "confirmPassword",
-            )}
-            showDescription
-            fieldProps={{
-              placeholder: "변경할 비밀번호",
-              type: "password",
-            }}
-          />
-          <FormController
-            form={form}
-            type="input"
-            name="confirmPassword"
-            revalidationHandlers={getMultipleRevalidationHandlers("password")}
-            showDescription
-            fieldProps={{
-              placeholder: "비밀번호 확인",
-              type: "password",
-            }}
-          />
-        </div>
-        <SubmitButton isActive={isActive} disabled={!isActive}>
-          수정하기
-        </SubmitButton>
+        {!data?.isOAuthAccount && (
+          <>
+            <FormController
+              form={form}
+              name="currentPassword"
+              type="input"
+              showLabel
+              labelProps={{ children: "비밀번호 변경", className: labelStyle }}
+              fieldProps={{
+                placeholder: "기존 비밀번호",
+                className: width,
+                type: "password",
+              }}
+            />
+            <div className={passwordWrapper}>
+              <FormController
+                form={form}
+                type="input"
+                name="changePassword"
+                revalidationHandlers={getMultipleRevalidationHandlers(
+                  "confirmPassword",
+                )}
+                showDescription
+                fieldProps={{
+                  placeholder: "변경할 비밀번호",
+                  type: "password",
+                }}
+              />
+              <FormController
+                form={form}
+                type="input"
+                name="confirmPassword"
+                revalidationHandlers={getMultipleRevalidationHandlers(
+                  "password",
+                )}
+                showDescription
+                fieldProps={{
+                  placeholder: "비밀번호 확인",
+                  type: "password",
+                }}
+              />
+            </div>
+            <SubmitButton isActive={isActive} disabled={!isActive}>
+              수정하기
+            </SubmitButton>
+          </>
+        )}
 
         {match(bjNickname)
           .with(undefined, () => (

--- a/src/view/user/setting/MyProfile/EditForm/index.tsx
+++ b/src/view/user/setting/MyProfile/EditForm/index.tsx
@@ -16,10 +16,9 @@ import { contentStyle, formStyle, labelStyle } from "./index.css";
 import useEditForm from "./useEditForm";
 
 const EditForm = () => {
-  const { data } = useSession();
-  const user = data?.user!;
-  const isOAuthAccount = data?.isOAuthAccount!;
-  const { form, handleSubmit, isActive } = useEditForm(user);
+  const session = useSession();
+  const isOAuthAccount = session.data?.isOAuthAccount!;
+  const { form, handleSubmit, isActive } = useEditForm(session);
   const { isOpen, open, close } = useBooleanState();
 
   return (

--- a/src/view/user/setting/MyProfile/EditForm/index.tsx
+++ b/src/view/user/setting/MyProfile/EditForm/index.tsx
@@ -33,7 +33,7 @@ const EditForm = () => {
   const handleSubmit = async (values: z.infer<typeof baseEditSchema>) => {
     try {
       await _handleSubmit(values);
-      await update(getSession());
+      await update(await getSession());
       showToast("정상적으로 수정이 되었어요", "success");
     } catch (_err) {
       showToast("정상적으로 수정되지 않았어요.", "error");

--- a/src/view/user/setting/MyProfile/EditForm/index.tsx
+++ b/src/view/user/setting/MyProfile/EditForm/index.tsx
@@ -11,11 +11,15 @@ import {
   editCardStyle,
   footerStyle,
 } from "@/view/user/setting/MyProfile/index.css";
+import { useSession } from "next-auth/react";
 import { contentStyle, formStyle, labelStyle } from "./index.css";
 import useEditForm from "./useEditForm";
 
 const EditForm = () => {
-  const { form, handleSubmit, isActive } = useEditForm();
+  const { data } = useSession();
+  const user = data?.user!;
+  const isOAuthAccount = data?.isOAuthAccount!;
+  const { form, handleSubmit, isActive } = useEditForm(user);
   const { isOpen, open, close } = useBooleanState();
 
   return (
@@ -74,7 +78,11 @@ const EditForm = () => {
           </Card>
         </form>
       </Form>
-      <WithdrawModal isOpen={isOpen} onClose={close} />
+      <WithdrawModal
+        isOpen={isOpen}
+        onClose={close}
+        isOAuthAccount={isOAuthAccount}
+      />
     </>
   );
 };

--- a/src/view/user/setting/MyProfile/EditForm/index.tsx
+++ b/src/view/user/setting/MyProfile/EditForm/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useBooleanState } from "@/common/hook/useBooleanState";
+import { useToast } from "@/common/hook/useToast";
 import { handleA11yClick } from "@/common/util/dom";
 import Card from "@/shared/component/Card";
 import { Form, FormController } from "@/shared/component/Form";
@@ -11,16 +12,33 @@ import {
   editCardStyle,
   footerStyle,
 } from "@/view/user/setting/MyProfile/index.css";
-import { useSession } from "next-auth/react";
+import { getSession, useSession } from "next-auth/react";
+import type { z } from "zod";
 import { contentStyle, formStyle, labelStyle } from "./index.css";
+import type { baseEditSchema } from "./schema";
 import useEditForm from "./useEditForm";
 
 const EditForm = () => {
-  const session = useSession();
-  const isOAuthAccount = session.data?.isOAuthAccount!;
-  const { form, handleSubmit, isActive } = useEditForm(session);
+  const { data, update } = useSession();
+  const {
+    form,
+    handleSubmit: _handleSubmit,
+    isActive,
+  } = useEditForm(data?.user!);
+  const { showToast } = useToast();
   const { isOpen, open, close } = useBooleanState();
 
+  const isOAuthAccount = data?.isOAuthAccount!;
+
+  const handleSubmit = async (values: z.infer<typeof baseEditSchema>) => {
+    try {
+      await _handleSubmit(values);
+      await update(getSession());
+      showToast("정상적으로 수정이 되었어요", "success");
+    } catch (_err) {
+      showToast("정상적으로 수정되지 않았어요.", "error");
+    }
+  };
   return (
     <>
       <Form {...form}>

--- a/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
+++ b/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
@@ -1,15 +1,12 @@
 import { patchMyInfoAction } from "@/app/[user]/setting/action";
-import { useToast } from "@/common/hook/useToast";
 import { createFormDataFromDirtyFields } from "@/shared/util/form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { getSession, type useSession } from "next-auth/react";
+import type { User } from "next-auth";
 import { useForm } from "react-hook-form";
 import type { z } from "zod";
 import { baseEditSchema } from "./schema";
 
-const useEditForm = (session: ReturnType<typeof useSession>) => {
-  const { data, update } = session;
-  const user = data?.user;
+const useEditForm = (user: User) => {
   const form = useForm<z.infer<typeof baseEditSchema>>({
     resolver: zodResolver(baseEditSchema),
     mode: "onChange",
@@ -20,7 +17,6 @@ const useEditForm = (session: ReturnType<typeof useSession>) => {
       description: user?.description,
     },
   });
-  const { showToast } = useToast();
   const isActive = form.formState.isValid && form.formState.isDirty;
 
   const handleSubmit = async (values: z.infer<typeof baseEditSchema>) => {
@@ -35,8 +31,6 @@ const useEditForm = (session: ReturnType<typeof useSession>) => {
     }
 
     await patchMyInfoAction(data);
-    await update(await getSession());
-    showToast("정상적으로 수정이 되었어요", "success");
   };
 
   return {

--- a/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
+++ b/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
@@ -2,13 +2,14 @@ import { patchMyInfoAction } from "@/app/[user]/setting/action";
 import { useToast } from "@/common/hook/useToast";
 import { createFormDataFromDirtyFields } from "@/shared/util/form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import type { User } from "next-auth";
-import { getSession } from "next-auth/react";
+import { getSession, type useSession } from "next-auth/react";
 import { useForm } from "react-hook-form";
 import type { z } from "zod";
 import { baseEditSchema } from "./schema";
 
-const useEditForm = (user: User) => {
+const useEditForm = (session: ReturnType<typeof useSession>) => {
+  const { data, update } = session;
+  const { user } = data!;
   const form = useForm<z.infer<typeof baseEditSchema>>({
     resolver: zodResolver(baseEditSchema),
     mode: "onChange",
@@ -34,7 +35,7 @@ const useEditForm = (user: User) => {
     }
 
     await patchMyInfoAction(data);
-    await session.update(await getSession());
+    await update(await getSession());
     showToast("정상적으로 수정이 되었어요", "success");
   };
 

--- a/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
+++ b/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
@@ -9,7 +9,7 @@ import { baseEditSchema } from "./schema";
 
 const useEditForm = (session: ReturnType<typeof useSession>) => {
   const { data, update } = session;
-  const { user } = data!;
+  const user = data?.user;
   const form = useForm<z.infer<typeof baseEditSchema>>({
     resolver: zodResolver(baseEditSchema),
     mode: "onChange",

--- a/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
+++ b/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
@@ -2,15 +2,13 @@ import { patchMyInfoAction } from "@/app/[user]/setting/action";
 import { useToast } from "@/common/hook/useToast";
 import { createFormDataFromDirtyFields } from "@/shared/util/form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { getSession, useSession } from "next-auth/react";
+import type { User } from "next-auth";
+import { getSession } from "next-auth/react";
 import { useForm } from "react-hook-form";
 import type { z } from "zod";
 import { baseEditSchema } from "./schema";
 
-const useEditForm = () => {
-  const session = useSession();
-  const user = session.data?.user;
-
+const useEditForm = (user: User) => {
   const form = useForm<z.infer<typeof baseEditSchema>>({
     resolver: zodResolver(baseEditSchema),
     mode: "onChange",

--- a/src/view/user/setting/MyProfile/WithdrawModal/index.tsx
+++ b/src/view/user/setting/MyProfile/WithdrawModal/index.tsx
@@ -13,10 +13,15 @@ import { useForm } from "react-hook-form";
 import type { z } from "zod";
 
 type WithdrawModalProps = {
+  isOAuthAccount: boolean;
   isOpen: boolean;
   onClose: () => void;
 };
-const WithdrawModal = ({ isOpen, onClose }: WithdrawModalProps) => {
+const WithdrawModal = ({
+  isOpen,
+  onClose,
+  isOAuthAccount,
+}: WithdrawModalProps) => {
   const form = useForm<z.infer<typeof passwordSchema>>({
     resolver: zodResolver(passwordSchema),
     mode: "onTouched",
@@ -27,12 +32,17 @@ const WithdrawModal = ({ isOpen, onClose }: WithdrawModalProps) => {
   const { mutate } = useDeleteMeMutation();
   const isActive = form.formState.isValid;
 
-  const handleSubmit = (values: z.infer<typeof passwordSchema>) => {
-    mutate(values.password, {
-      onError: () => {
-        form.setError("password", { message: "비밀번호가 올바르지 않습니다." });
+  const handleSubmit = ({ password }: z.infer<typeof passwordSchema>) => {
+    mutate(
+      { password, isOAuthAccount },
+      {
+        onError: () => {
+          form.setError("password", {
+            message: "비밀번호가 올바르지 않습니다.",
+          });
+        },
       },
-    });
+    );
   };
 
   return (


### PR DESCRIPTION
## ✅ Done Task
  - [x] `Session`에 `isOAuthAccount` 추가
  - [x] `isOAuthAccount` 여부에 따라 비밀번호 재설정 표시
  - [x] 회원탈퇴 api에 `isOAuthAccount` 필드 추가

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- as-is
    ```tsx
    const useEditForm = () => { ... }

    const WithdrawModal = ({ isOpen, onClose }: WithdrawModalProps) => {
    ...
      mutate(values.password, { onError: ... } );
    ```
- to-be
    ```tsx
    const useEditForm = (session: ReturnType<typeof useSession>) => { ... }

    const WithdrawModal = ({ isOpen, onClose, isOAuthAccount }: WithdrawModalProps) => {
    ...
      mutate( { password, isOAuthAccount }, { onError: ... } );
    ```
작업을 요약하면 to-be를 위한 수정들을 했습니다.
회원탈퇴 모달도 세션의 데이터인 `isOAuthAccount`를 필요로 하게 됨에 따라 `useEditForm`에서 사용하던 `useSession`을 `EditForm` 컴포넌트로 옮겨서 `useEditForm`의 인자와 `WithdrawModal`의 props로 넘겨주도록 변경했습니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
- `isOAuthAccount == true` 일 때 계정관리 탭(비밀번호 재설정)
![image](https://github.com/user-attachments/assets/00aaa164-78d2-47cf-86d0-baf42aed144f)
