### PR TITLE
[ Feat ] 프로필 이미지 UI 변경

### DIFF
--- a/src/common/util/string.ts
+++ b/src/common/util/string.ts
@@ -10,3 +10,11 @@
 export function camelToKebab(str: string): string {
   return str.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
 }
+
+export const colorToRgba = (hex: string, opacity: number) => {
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
+
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+};

--- a/src/shared/component/EditAvatar/index.css.ts
+++ b/src/shared/component/EditAvatar/index.css.ts
@@ -1,3 +1,4 @@
+import { colorToRgba } from "@/common/util/string";
 import { theme } from "@/styles/themes.css";
 import { style } from "@vanilla-extract/css";
 
@@ -22,6 +23,42 @@ export const iconStyle = style({
   borderRadius: "50%",
   opacity: 0.9,
 
+  cursor: "pointer",
+});
+
+export const buttonWrapper = style({
+  position: "absolute",
+  inset: 0,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "0.6rem",
+
+  borderRadius: "50%",
+  backgroundColor: "rgba(0, 0, 0, 0.4)",
+  opacity: 0,
+  transition: "opacity 0.2s ease-in-out",
+
+  selectors: {
+    "&:hover, &:focus-within": {
+      opacity: 1,
+    },
+  },
+});
+
+export const actionButton = style({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+
+  width: "3.3rem",
+  height: "2.1rem",
+
+  borderRadius: "1rem",
+  border: `1px solid ${colorToRgba("#ffffff", 0.5)}`,
+
+  backgroundColor: colorToRgba("#bcc0cd", 0.5),
+  color: theme.color.white,
   cursor: "pointer",
 });
 

--- a/src/shared/component/EditAvatar/index.tsx
+++ b/src/shared/component/EditAvatar/index.tsx
@@ -14,7 +14,7 @@ interface EditAvatarProps extends Omit<ImageProps, "src" | "alt" | "onChange"> {
   src?: string;
   alt?: string;
   name?: string;
-  onChange?: (img?: Blob) => void;
+  onChange?: (img: Blob | null) => void;
   variant?: "default" | "secondary";
 }
 
@@ -49,7 +49,7 @@ const EditAvatar = ({
 
   const handleDelete = () => {
     setPickedImage(null);
-    onChange?.();
+    onChange?.(null);
   };
 
   return (

--- a/src/shared/component/EditAvatar/index.tsx
+++ b/src/shared/component/EditAvatar/index.tsx
@@ -1,17 +1,20 @@
 "use client";
 import grayDefaultImg from "@/asset/img/img_card_profile.png";
 import defaultImg from "@/asset/img/small_logo.png";
-import { IcnEditProfile } from "@/asset/svg";
 import Avatar from "@/common/component/Avatar";
-import { iconStyle, inputStyle } from "@/shared/component/EditAvatar/index.css";
+import {
+  actionButton,
+  buttonWrapper,
+  inputStyle,
+} from "@/shared/component/EditAvatar/index.css";
 import type { ImageProps } from "next/image";
-import { type ChangeEvent, useState } from "react";
+import { type ChangeEvent, useRef, useState } from "react";
 
 interface EditAvatarProps extends Omit<ImageProps, "src" | "alt" | "onChange"> {
   src?: string;
   alt?: string;
   name?: string;
-  onChange?: (img: Blob) => void;
+  onChange?: (img?: Blob) => void;
   variant?: "default" | "secondary";
 }
 
@@ -24,6 +27,8 @@ const EditAvatar = ({
   ...props
 }: EditAvatarProps) => {
   const [pickedImage, setPickedImage] = useState<string | null>(src || null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -38,11 +43,13 @@ const EditAvatar = ({
     fileReader.readAsDataURL(file);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<SVGElement>) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      document.getElementById("edit-avatar-label")?.click();
-    }
+  const handleEdit = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleDelete = () => {
+    setPickedImage(null);
+    onChange?.();
   };
 
   return (
@@ -52,18 +59,29 @@ const EditAvatar = ({
       size="large"
       {...props}
     >
-      <label id="edit-avatar-label" htmlFor="edit-avatar">
-        <IcnEditProfile
-          className={iconStyle}
-          tabIndex={0}
-          onKeyDown={handleKeyDown}
-        />
-      </label>
+      <div className={buttonWrapper}>
+        <button
+          type="button"
+          className={actionButton}
+          onClick={handleEdit}
+          aria-label="프로필 사진 수정"
+        >
+          수정
+        </button>
+        <button
+          type="button"
+          className={actionButton}
+          onClick={handleDelete}
+          aria-label="프로필 사진 삭제"
+        >
+          삭제
+        </button>
+      </div>
       <input
+        ref={fileInputRef}
         className={inputStyle}
         type="file"
         name={name}
-        id="edit-avatar"
         accept="image/*"
         onChange={handleImageChange}
       />

--- a/src/shared/util/form.ts
+++ b/src/shared/util/form.ts
@@ -87,6 +87,8 @@ export const createFormDataFromDirtyFields = <T extends z.ZodRawShape>(
       if (!isDirty) return acc;
 
       const value = values[key] as ValueType;
+
+      /** 이미지가 수정됐는데 값이 있으면 기본이미지 X / 값이 없으면 기본이미지 O */
       if (key.includes("Image")) {
         acc.isDefaultImage = !value;
       } else if (value instanceof Date) {
@@ -97,12 +99,8 @@ export const createFormDataFromDirtyFields = <T extends z.ZodRawShape>(
 
       return acc;
     },
-    { isDefaultImage: false } as Record<string, ValueType>,
+    {} as Record<string, ValueType>,
   );
-
-  if (!Object.hasOwn(dirtyFields, "groupImage")) {
-    requestData.isDefaultImage = false;
-  }
 
   /** 중복 허용하지 않는 nickname 필드는 dirty하지 않을 시 formData에서 제거 */
   if (!Object.hasOwn(dirtyFields, "nickname") && values.nickname) {

--- a/src/view/user/setting/MyProfile/EditForm/index.tsx
+++ b/src/view/user/setting/MyProfile/EditForm/index.tsx
@@ -34,6 +34,12 @@ const EditForm = () => {
     try {
       await _handleSubmit(values);
       await update(await getSession());
+
+      form.reset(values, {
+        keepValues: true, // 현재 입력값 유지
+        keepDirty: false, // dirty 상태 초기화
+      });
+
       showToast("정상적으로 수정이 되었어요", "success");
     } catch (_err) {
       showToast("정상적으로 수정되지 않았어요.", "error");


### PR DESCRIPTION
## ✅ Done Task
  - [x] 프로필 이미지 버튼 변경(수정, 삭제)
  - [x] submit 성공 시 dirtyFields 리셋

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
버튼 만들때 도형은 투명하게, 글자는 투명하지 않게 하는 법을 잊어버렸어서 다시 적어봅니다.
- 투명하게 할 부분 : `rgba(r, g, b, a)` 사용
- 불투명하게 할 부분 : 평범하게 색상 사용

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 수정, 삭제 버튼 디자인
rgba를 적용할 때 색상값을 가져오기 위해 `theme.color.xxx`를 사용하면 var(--xxx...) 로 된 css 변수 이름이 반환되기에 부득이하게 색상 hex값과 hex값->rgba string 변환 함수를 사용했습니다.
재사용을 위한 더 나은 방법은 `theme.color`의 실제 값을 쓰기 위해 src/styles/theme.css.ts에 있는 함수인 `createGlobalTheme()`에 인자로 넣은 색상 object를 분리하여 따로 export 해서 쓰는 건데, 해도 괜찮을 지 의견 남겨주시면 좋겠네요.

- 수정, 삭제 인터랙션
기존에 label과 input을 id로 연결해 파일관리자를 열던 방식에서 버튼 인터랙션으로 변경하였습니다. 

- submit 이후 폼 리셋
다음 상황에서 불편함이 있습니다.
  1. 프로필 사진이 없는 상태에서 수정
  2. 수정 버튼 눌러서 submit, 변경 완료
  3. 사진 삭제
  4. dirtyFields(수정된 폼 요소)가 없는 것으로 인식하여 수정 버튼 비활성화

  iii. 을 새로고침 없이 가능하게 하기 위해 submit 성공 시 폼 기본값을 submit한 상태를 기준으로 리셋해주도록 했습니다.
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
![SmartSelect_20250504_171845_Chrome](https://github.com/user-attachments/assets/c9fcfd77-cf6a-4c8c-8a4d-632750dc2dc7)
