### PR TITLE
[ Fix ] 알람 설정 아이콘 수정

### DIFF
--- a/src/view/user/setting/SettingStep/index.tsx
+++ b/src/view/user/setting/SettingStep/index.tsx
@@ -1,9 +1,4 @@
-import {
-  IcnNotifications,
-  IcnPencil,
-  IcnSetting,
-  IcnSquare,
-} from "@/asset/svg";
+import { IcnAlarm, IcnPencil, IcnSetting, IcnSquare } from "@/asset/svg";
 import { theme } from "@/styles/themes.css";
 import {
   barStyle,
@@ -21,18 +16,17 @@ type SettingStepProps = {
   step: SettingSteps;
   setStep: Dispatch<SetStateAction<SettingSteps>>;
 };
+const steps = [
+  { type: "my-profile", label: "내 프로필", Icon: IcnSquare },
+  { type: "study-setting", label: "스터디 관리", Icon: IcnPencil },
+  { type: "account-setting", label: "계정 관리", Icon: IcnSetting },
+  {
+    type: "notification-setting",
+    label: "알람 설정",
+    Icon: IcnAlarm,
+  },
+];
 const SettingStep = ({ step, setStep }: SettingStepProps) => {
-  const steps = [
-    { type: "my-profile", label: "내 프로필", Icon: IcnSquare },
-    { type: "study-setting", label: "스터디 관리", Icon: IcnPencil },
-    { type: "account-setting", label: "계정 관리", Icon: IcnSetting },
-    {
-      type: "notification-setting",
-      label: "알람 설정",
-      Icon: IcnNotifications,
-    },
-  ];
-
   return (
     <ul className={wrapper}>
       {steps.map(({ type, label, Icon }) => {


### PR DESCRIPTION
## ✅ Done Task
  - [x] 알람 설정 아이콘 변경
  - [x] 컴포넌트 함수에서 아이콘 배열 분리

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
전에 아이콘 종류가 추가되면서 알람 아이콘 파일명도 바뀌었던걸로 기억하는데 그것의 사이드 이펙트였었네요.
활성화가 안되던 것은 svg의 `fill`이나 `color` 속성을 바꾸는 것으로 구현 해놨는데 아이콘 파일이 바뀌어서 바꿔야 할 속성이 아닌것을 바꾸는 바람에 그런거였구요.

추가로 아이콘 목록 배열을 튜플로써 사용중이길래 컴포넌트에서 분리했습니다.
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
![SmartSelect_20250505_181810_Chrome](https://github.com/user-attachments/assets/4c566fb4-f715-4857-abfb-05db71ccae4d)
