### PR TITLE
[ Fix ] 그룹 초대 재수락 시 에러 핸들링

### DIFF
--- a/src/app/group/[groupId]/withdraw/action.ts
+++ b/src/app/group/[groupId]/withdraw/action.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export const revalidateUserPage = (nickname: string) => {
+  revalidatePath(`/${nickname}`);
+};

--- a/src/app/group/[groupId]/withdraw/page.tsx
+++ b/src/app/group/[groupId]/withdraw/page.tsx
@@ -6,6 +6,7 @@ import WithdrawDialog from "@/shared/component/WithdrawDialog";
 import { sidebarWrapper } from "@/styles/shared.css";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { revalidateUserPage } from "./action";
 
 const WithdrawPage = ({ params }: { params: { groupId: string } }) => {
   const router = useRouter();
@@ -16,7 +17,10 @@ const WithdrawPage = ({ params }: { params: { groupId: string } }) => {
       <Modal isOpen={true} onClose={() => router.back()} hasCloseBtn>
         <WithdrawDialog
           groupId={+params.groupId}
-          onSuccess={() => router.push(`/${userNickname}`)}
+          onSuccess={() => {
+            revalidateUserPage(userNickname!);
+            router.push(`/${userNickname}`);
+          }}
         />
       </Modal>
     </main>

--- a/src/app/join-group/[code]/action.ts
+++ b/src/app/join-group/[code]/action.ts
@@ -1,8 +1,30 @@
 "use server";
 import { postJoinGroupByCode } from "@/app/api/groups";
+import { HTTPError } from "ky";
 
-export const joinGroupAction = async (code: string) => {
-  const response = await postJoinGroupByCode(code);
+type JoinGroupResponse = {
+  status: number;
+  data?: string;
+  error?: string;
+};
 
-  return response.json();
+export const joinGroupAction = async (
+  code: string,
+): Promise<JoinGroupResponse> => {
+  try {
+    const response = await postJoinGroupByCode(code);
+    return {
+      status: response.status,
+      data: await response.json(),
+    };
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      return {
+        ...(await error.response.json()),
+      };
+    }
+    return {
+      status: 500,
+    };
+  }
 };

--- a/src/app/join-group/[code]/page.tsx
+++ b/src/app/join-group/[code]/page.tsx
@@ -15,27 +15,27 @@ import {
   errorWrapper,
   wrapper,
 } from "@/view/user/join-group/index.css";
-import { useMutation } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 const JoinGroupPage = ({ params: { code } }: { params: { code: string } }) => {
   const [isJoinModalOpen, setIsJoinModalOpen] = useState(true);
-
   const { data: groupData } = useGroupByCodeQuery(code);
   const userNickname = useSession().data?.user?.nickname;
   const router = useRouter();
-  const { mutate: joinGroupMutate } = useMutation({
-    mutationFn: (code: string) => joinGroupAction(code),
-    onSuccess: () => {
+
+  const handleJoin = async () => {
+    const result = await joinGroupAction(code);
+
+    if (result.status === 200) {
       router.push(`/group/${groupData?.id}`);
-    },
-    onError: (error: Error) => {
-      if (error.message.includes(`${HTTP_ERROR_STATUS.BAD_REQUEST}`))
-        setIsJoinModalOpen(false);
-    },
-  });
+    } else if (result.status === HTTP_ERROR_STATUS.BAD_REQUEST) {
+      setIsJoinModalOpen(false);
+    } else {
+      console.error(result);
+    }
+  };
 
   const handleReject = () => {
     if (isJoinModalOpen) router.push(`/${userNickname}`);
@@ -53,14 +53,19 @@ const JoinGroupPage = ({ params: { code } }: { params: { code: string } }) => {
           <GroupInfoCard groupInfo={groupData} />
           <DecisionPrompt owner={groupData.ownerNickname} />
           <div className={btnWrapper}>
-            <Button type="button" size="medium" color="lg">
+            <Button
+              type="button"
+              size="medium"
+              color="lg"
+              onClick={handleReject}
+            >
               거절하기
             </Button>
             <Button
               type="button"
               size="medium"
               color="purple"
-              onClick={() => joinGroupMutate(code)}
+              onClick={handleJoin}
             >
               수락하기
             </Button>


### PR DESCRIPTION
## ✅ Done Task
  - [x] 초대 재수락 시 에러처리 정상화
  - [x] 탈퇴 시 대시보드 갱신 안되는 버그 수정

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
static page 캐시 초기화는 서버액션으로 만든 `revalidatePath()`로 해야합니다.

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 재수락 시 에러처리 안되던 원인
next의 dev모드와 start모드의 서버액션 처리가 다르던 게 문제였습니다. dev모드에서는 기존 코드처럼 서버액션의 throw를 감지하여 `useMutation`의 `onError`로 넘어갈 수 있으나, start모드에서는 그렇지 못하고 next서버 에러만 출력된 채 mutation 함수가 중지됩니다. 원인은 보안을 위해 start모드에서는 dev보다 간략화된 에러처리 방식을 사용하기 때문에 onError를 트리거하는 방식이 아니게 돼서 그런걸로 추측중인데 자세한건 모르겠네요. [참고](https://joulev.dev/blogs/throwing-expected-errors-in-react-server-actions)

  여튼 그에 따라 `loginAction`의 구현을 참고하여 서버액션의 catch문에서도 throw대신 return을 해주고, 서버액션을 호출하는 곳은 `useMutation`대신 단순히 리턴값을 확인 후 status값에 따라 분기 처리를 하는 방식으로 교체하였습니다. 


- 그룹 탈퇴 시 캐시 초기화
테스트를 하며 그룹가입, 탈퇴를 반복하다 보니 발견한건데, 탈퇴하고 대시보드 페이지를 가 보면 탈퇴한 그룹이 그대로 남아있었습니다. static page라 캐시 초기화를 안 해서 발생한 것으로 인지하고 `revalidatePath`를 사용해 처리했습니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->