### PR TITLE
[ Fix ] 유저정보 수정 api 에러 메세지 표시

### DIFF
--- a/src/app/[user]/setting/action.ts
+++ b/src/app/[user]/setting/action.ts
@@ -1,13 +1,23 @@
 "use server";
+import type { APIResponse } from "@/app/api/type";
 import { patchMyInfo, patchPassword } from "@/app/api/users";
 import type { PasswordRequest } from "@/app/api/users/type";
 import { isHTTPError } from "@/shared/util/error";
+import { HTTPError } from "ky";
 
-export const patchMyInfoAction = async (formData: FormData) => {
+export const patchMyInfoAction = async (
+  formData: FormData,
+): Promise<APIResponse> => {
   try {
     await patchMyInfo(formData);
-  } catch {
-    throw new Error("fail to patch my info");
+    return {
+      status: 200,
+    };
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      return await error.response.json();
+    }
+    throw new Error("Failed patch my info");
   }
 };
 

--- a/src/app/[user]/setting/query.ts
+++ b/src/app/[user]/setting/query.ts
@@ -17,6 +17,7 @@ import { deleteMe } from "@/app/api/users";
 import type { DeleteUserRequest, PasswordRequest } from "@/app/api/users/type";
 import { useToast } from "@/common/hook/useToast";
 import { HTTP_ERROR_STATUS } from "@/shared/constant/api";
+import { setAccessToken } from "@/shared/util/token";
 import {
   useMutation,
   useQueryClient,
@@ -221,6 +222,7 @@ export const useDeleteMeMutation = () => {
       deleteMe({ password, isOAuthAccount }),
     onSuccess: async () => {
       showToast("정상적으로 계정이 삭제되었습니다.", "success");
+      setAccessToken("");
       await signOut({
         redirectTo: "/",
       });

--- a/src/app/api/auth/actions.ts
+++ b/src/app/api/auth/actions.ts
@@ -11,7 +11,7 @@ import { isRedirectError } from "next/dist/client/components/redirect";
 import { redirect } from "next/navigation";
 import type { z } from "zod";
 import { postReissueToken, postSignUp } from ".";
-import type { APIError } from "../type";
+import type { APIResponse } from "../type";
 
 export const signUpAction = async (token: string, formData: FormData) => {
   try {
@@ -39,7 +39,7 @@ export const loginAction = async (values: z.infer<typeof loginSchema>) => {
             message: error.cause?.err?.message,
             msg: (await (
               error.cause?.err as HTTPError
-            ).response?.json()) as APIError,
+            ).response?.json()) as APIResponse,
             type: error.type,
           };
         }

--- a/src/app/api/index.ts
+++ b/src/app/api/index.ts
@@ -34,8 +34,14 @@ const insertNewToken: BeforeRetryHook = async ({
   retryCount,
 }) => {
   if (retryCount === 2) {
-    isServer ? await signOut() : await cSignOut();
+    if (isServer) {
+      await signOut();
+    } else {
+      await cSignOut();
+      setAccessToken("");
+    }
     ky.stop;
+    return;
   }
   const { response } = error as HTTPError;
   if (

--- a/src/app/api/notifications/index.ts
+++ b/src/app/api/notifications/index.ts
@@ -1,21 +1,15 @@
 import { kyJsonWithTokenInstance } from "@/app/api";
-import { logoutAction } from "@/app/api/auth/actions";
 import type {
   NotificationItem,
   NotificationSettingContent,
 } from "@/app/api/notifications/type";
 
 export const getNotificationList = async () => {
-  try {
-    const response = await kyJsonWithTokenInstance
-      .get<NotificationItem[]>("api/notifications")
-      .json();
+  const response = await kyJsonWithTokenInstance
+    .get<NotificationItem[]>("api/notifications")
+    .json();
 
-    return response;
-  } catch (error) {
-    await logoutAction();
-    throw error;
-  }
+  return response;
 };
 
 export const patchAllNotificationRead = () => {

--- a/src/app/api/type.ts
+++ b/src/app/api/type.ts
@@ -1,9 +1,22 @@
 import type { SolutionContent } from "@/app/api/solutions/type";
+import type { HTTPErrorStatusValues } from "@/shared/constant/api";
 
-export type APIError = {
-  error: string;
+type BaseAPIResponse = {
   status: number;
+  message?: string | null;
 };
+
+type APISuccessResponse = BaseAPIResponse & {
+  status: 200;
+  data?: string;
+};
+
+type APIErrorResponse = BaseAPIResponse & {
+  status: HTTPErrorStatusValues;
+  error: string;
+};
+
+export type APIResponse = APISuccessResponse | APIErrorResponse;
 
 export type PaginationResponse = {
   totalPages: number;

--- a/src/app/api/users/index.ts
+++ b/src/app/api/users/index.ts
@@ -4,7 +4,11 @@ import {
   kyJsonWithTokenInstance,
 } from "@/app/api";
 import type { GroupListResponse } from "@/app/api/groups/type";
-import type { MySolutionRequest, MySolutionResponse } from "@/app/api/type";
+import type {
+  APIResponse,
+  MySolutionRequest,
+  MySolutionResponse,
+} from "@/app/api/type";
 import type {
   DeleteUserRequest,
   PasswordRequest,
@@ -146,9 +150,11 @@ export const deleteMe = async ({
 };
 
 export const patchMyInfo = async (formData: FormData) => {
-  const response = await kyFormWithTokenInstance.patch("api/users/me", {
-    body: formData,
-  });
+  const response = await kyFormWithTokenInstance
+    .patch<APIResponse>("api/users/me", {
+      body: formData,
+    })
+    .json();
 
   return response;
 };

--- a/src/app/query.ts
+++ b/src/app/query.ts
@@ -5,14 +5,10 @@ import {
   patchNotificationRead,
 } from "@/app/api/notifications";
 import type { NotificationItem } from "@/app/api/notifications/type";
-import {
-  useMutation,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useNotificationsQuery = () => {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ["notifications"],
     queryFn: getNotificationList,
     staleTime: 0,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -41,7 +41,6 @@ export const {
         }
       } catch (err) {
         if (err instanceof HTTPError) {
-          console.warn("auth.ts:", await err.response.json());
           await signOut();
         }
       }

--- a/src/shared/component/Header/Profile.tsx
+++ b/src/shared/component/Header/Profile.tsx
@@ -7,7 +7,8 @@ import {
   dropdownTextStyle,
 } from "@/shared/component/Header/Profile.css";
 import { iconStyle } from "@/shared/component/Header/index.css";
-import { getSession, useSession } from "next-auth/react";
+import { setAccessToken } from "@/shared/util/token";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -19,7 +20,8 @@ const Profile = ({ ...props }: DropdownProps) => {
 
   const handleLogout = async () => {
     await logoutAction();
-    await session.update(await getSession());
+    await session.update(null);
+    setAccessToken("");
 
     router.push("/login");
   };

--- a/src/shared/constant/api.ts
+++ b/src/shared/constant/api.ts
@@ -9,4 +9,6 @@ export const HTTP_ERROR_STATUS = {
   INTERNAL_SERVER_ERROR: 500,
 } as const;
 
+export type HTTPErrorStatusValues =
+  (typeof HTTP_ERROR_STATUS)[keyof typeof HTTP_ERROR_STATUS];
 export const NO_RETRY_STATUSES = Object.values(HTTP_ERROR_STATUS) as number[];

--- a/src/shared/util/form.ts
+++ b/src/shared/util/form.ts
@@ -99,7 +99,7 @@ export const createFormDataFromDirtyFields = <T extends z.ZodRawShape>(
 
       return acc;
     },
-    {} as Record<string, ValueType>,
+    { isDefaultImage: false } as Record<string, ValueType>,
   );
 
   /** 중복 허용하지 않는 nickname 필드는 dirty하지 않을 시 formData에서 제거 */

--- a/src/view/login/LoginForm/useLoginForm.ts
+++ b/src/view/login/LoginForm/useLoginForm.ts
@@ -1,5 +1,6 @@
 import { loginAction } from "@/app/api/auth/actions";
 import { useTrack } from "@/shared/hook/useTrack";
+import { setAccessToken } from "@/shared/util/token";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { getSession, useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
@@ -45,6 +46,8 @@ const useLoginForm = () => {
       const newSession = await getSession();
       if (newSession) {
         session.update(newSession);
+        setAccessToken(newSession.accessToken);
+
         router.push(`/${newSession?.user?.nickname}`);
       }
       track("login_cta_button_click");

--- a/src/view/login/LoginForm/useLoginForm.ts
+++ b/src/view/login/LoginForm/useLoginForm.ts
@@ -34,10 +34,10 @@ const useLoginForm = () => {
     startTransition(async () => {
       const data = await loginAction(values);
 
-      if (data?.error) {
+      if (data && data.status !== 200) {
         form.setError(
-          data.msg?.error.includes("비밀번호") ? "password" : "identifier",
-          { message: data.msg?.error },
+          data.error.includes("비밀번호") ? "password" : "identifier",
+          { message: data.error },
         );
         return;
       }

--- a/src/view/user/setting/MyProfile/EditForm/index.tsx
+++ b/src/view/user/setting/MyProfile/EditForm/index.tsx
@@ -6,6 +6,7 @@ import { handleA11yClick } from "@/common/util/dom";
 import Card from "@/shared/component/Card";
 import { Form, FormController } from "@/shared/component/Form";
 import SubmitButton from "@/shared/component/SubmitButton";
+import { HTTP_ERROR_STATUS } from "@/shared/constant/api";
 import { handleOnChangeMode } from "@/shared/util/form";
 import WithdrawModal from "@/view/user/setting/MyProfile/WithdrawModal";
 import {
@@ -31,14 +32,18 @@ const EditForm = () => {
   const isOAuthAccount = data?.isOAuthAccount!;
 
   const handleSubmit = async (values: z.infer<typeof baseEditSchema>) => {
-    try {
-      await _handleSubmit(values);
+    const response = await _handleSubmit(values);
+    console.log({ response });
+    if (response.status === 200) {
       await update(await getSession());
-      showToast("정상적으로 수정이 되었어요", "success");
-    } catch (_err) {
+      showToast("정상적으로 수정되었어요.", "success");
+    } else if (response.status === HTTP_ERROR_STATUS.INTERNAL_SERVER_ERROR)
       showToast("정상적으로 수정되지 않았어요.", "error");
+    else {
+      showToast(response.error, "error");
     }
   };
+
   return (
     <>
       <Form {...form}>

--- a/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
+++ b/src/view/user/setting/MyProfile/EditForm/useEditForm.ts
@@ -30,7 +30,7 @@ const useEditForm = (user: User) => {
       data.append("profileImage", profileImage);
     }
 
-    await patchMyInfoAction(data);
+    return await patchMyInfoAction(data);
   };
 
   return {


### PR DESCRIPTION
close fe-63

## ✅ Done Task
  - [x] 토스트에 api에러 메세지 표시
  - [x] 유저 정보 수정 시 defaultValue도 조정
  - [x] 이미지 변경 시 File 객체간의 변경이면 dirty가 바뀌지 않던 버그 수정
  - [x] 몇몇 api 코드 정리
  - [x] 로그인, 로그아웃 시 내부 토큰 저장소도 수정 close fe-63

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
이미지같은 `File` 객체는 다른 `File` 객체로 변경해도 `dirtyField`라고 감지되질 않더라구요. 
첫 화면에서는 이미지가 `aws url`(string 타입)이라 `File`로 변경하면 타입이 다르니 감지할 수 있는데, `File` 객체끼리는 감지가 안되기에 감지할 수 있도록 로직을 추가해야 합니다.

1. 파일정보 필드 추가(파일 정보 비교)
파일 정보(파일명, 크기)를 조합하는 식으로 필드를 추가하고 이미지 변경 시 이 필드도 수정하도록 만드는 겁니다. 이후 정보 수정 api호출 시 파일정보 필드만 제외하고 보내는 식으로 변경 감지를 적용할 수 있습니다. 다만 이곳 저곳 변경해야할 부분이 많아서 이 방법은 별로라고 생각합니다.

2. 파일 변경 시 기본값을 초기화하여 변경 감지 시키기
`useEffect`와 `form.watch`를 통해 변경된 게 `profileImage`고 그 값이 `File`타입이면 `defaultValue`를 빈 값으로 만든 뒤 `profileImage`를 검사하여 dirty를 활성화하는 방식입니다.
어차피 같은 이미지를 넣지는 않을테고, 혹시 넣더라도 크게 문제가 되지 않기에 이 방법이 낫다고 생각합니다. 

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 에러메세지 표시
에러메세지 표시는 서버액션에서 api의 응답을 그대로 return하는 방식으로 구현했습니다.

- 토큰 저장소 수정
로그인, 로그아웃 시 클라용으로 만들었던 토큰 저장소를 수정하지 않고 있었어서 추가적인 세션 요청을 하거나 이전 계정의 토큰으로 요청을 보내는 등의 버그가 있었습니다. 
이는 ky 훅으로 잘 처리되긴 했었으나 쓸데없는 요청이 늘어나는 바람직하지 못한 로직이므로 로그인 시에는 토큰 저장소에 등록해주도록 하고, 로그아웃 시에는 토큰 저장소를 비우도록 했습니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
![화면 캡처 2025-05-11 113508](https://github.com/user-attachments/assets/87e9c487-904e-4278-ae04-0b2e6a8edbed)
