### PR TITLE
[ Fix ] 이상한 리다이렉트 정상화

### DIFF
--- a/src/app/api/auth/actions.ts
+++ b/src/app/api/auth/actions.ts
@@ -7,7 +7,7 @@ import { AuthError, type Session } from "next-auth";
 import { isRedirectError } from "next/dist/client/components/redirect";
 import { redirect } from "next/navigation";
 import type { z } from "zod";
-import { postReissueToken, postSignUp } from ".";
+import { postSignUp } from ".";
 import type { APIResponse } from "../type";
 
 export const signUpAction = async (token: string, formData: FormData) => {
@@ -49,21 +49,14 @@ export const loginAction = async (
 export const reIssueAction = async () => {
   try {
     const session = (await auth()) as Session;
-    const { accessToken: expiredAccessToken, refreshToken } = session;
-    const newTokens = await postReissueToken({
-      expiredAccessToken,
-      refreshToken,
-    });
-    await update({
-      ...session,
-      ...newTokens,
-    });
+    const newSession = await update(session);
 
-    return newTokens;
+    return newSession?.accessToken;
   } catch (error) {
     if (error instanceof HTTPError) {
-      console.warn("reIssueAction:", await error.response.json());
+      return await error.response.json<APIResponse>();
     }
+
     if (isRedirectError(error)) {
       throw error; // AuthError가 아닐 경우 다른 try catch로 보내주기 위함
     }

--- a/src/app/api/auth/index.ts
+++ b/src/app/api/auth/index.ts
@@ -9,9 +9,7 @@ import type {
   resetPasswordRequest,
   tokenResponse,
 } from "@/app/api/auth/type";
-import { HTTPError } from "ky";
 import { notFound } from "next/navigation";
-import { logoutAction } from "./actions";
 
 export const postSignUp = async (token: string, formData: FormData) => {
   const response = await kyFormInstance
@@ -34,19 +32,12 @@ export const postSignin = async (formData: SignInRequest) => {
 };
 
 export const postReissueToken = async (requestData: reissueTokenRequest) => {
-  let response = null;
-  try {
-    response = await kyJsonInstance
-      .post<tokenResponse>("api/auth/reissue-token", {
-        json: requestData,
-      })
-      .json();
-  } catch (error) {
-    if (error instanceof HTTPError && error.response.status === 401) {
-      await logoutAction();
-    }
-    throw error;
-  }
+  const response = await kyJsonInstance
+    .post<tokenResponse>("api/auth/reissue-token", {
+      json: requestData,
+    })
+    .json();
+
   return response;
 };
 

--- a/src/app/api/users/index.ts
+++ b/src/app/api/users/index.ts
@@ -175,8 +175,8 @@ export const patchPassword = async ({
   return response;
 };
 
-export const patchBjNickname = async (bjNickName: string) => {
-  const response = await kyJsonWithTokenInstance.patch(
+export const postBjNickname = async (bjNickName: string) => {
+  const response = await kyJsonWithTokenInstance.post(
     "api/users/baekjoon-nickname",
     {
       json: {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -20,7 +20,7 @@ export const {
     error: "/error",
   },
   callbacks: {
-    async jwt({ token, user, trigger }) {
+    async jwt({ token, user, trigger, session }) {
       try {
         if (trigger === "signIn") {
           token.user = user as AdapterUser;
@@ -28,10 +28,11 @@ export const {
           token.refreshToken = user.refreshToken;
           token.accessTokenExpires = jwtDecode(user.accessToken).exp! * 1000;
         } else if (trigger === "update") {
-          if (token.accessTokenExpires - Date.now() < 1000 * 60 * 5) {
+          // useSession().update()의 인자는 session 객체
+          if (session.accessTokenExpires - Date.now() < 1000 * 60 * 5) {
             const { accessToken, refreshToken } = await postReissueToken({
-              expiredAccessToken: token.accessToken,
-              refreshToken: token.refreshToken,
+              expiredAccessToken: session.accessToken,
+              refreshToken: session.refreshToken,
             });
             token.accessToken = accessToken;
             token.refreshToken = refreshToken;

--- a/src/view/group/dashboard/NoticeModal/NoticeList/index.tsx
+++ b/src/view/group/dashboard/NoticeModal/NoticeList/index.tsx
@@ -36,7 +36,7 @@ const NoticeList = () => {
     totalPages,
     setCurrentPage,
   } = usePaginationQuery({
-    queryKey: ["notices", groupId],
+    queryKey: ["notices", +groupId],
     queryFn: (page) => getNotices({ groupId: +groupId, page }),
   });
   const noticeList = noticeData?.content;

--- a/src/view/user/setting/AccountManagement/AccountManagementForm/IdRegisterForm.tsx
+++ b/src/view/user/setting/AccountManagement/AccountManagementForm/IdRegisterForm.tsx
@@ -1,4 +1,4 @@
-import { patchBjNickname } from "@/app/api/users";
+import { postBjNickname } from "@/app/api/users";
 import Button from "@/common/component/Button";
 import Input from "@/common/component/Input";
 import SupportingText from "@/common/component/SupportingText";
@@ -12,9 +12,9 @@ import type { z } from "zod";
 import {
   registerModalContainerStyle,
   registerModalDescriptionStyle,
+  registerModalHeadingStyle,
   registerModalTextContainerStyle,
 } from "./index.css";
-import { registerModalHeadingStyle } from "./index.css";
 import { formSchema } from "./schema";
 
 type IdRegisterFormProps = {
@@ -43,7 +43,7 @@ const IdRegisterForm = ({ onSuccess }: IdRegisterFormProps) => {
     if (isInvalid) return;
 
     try {
-      const response = await patchBjNickname(form.bjNickname);
+      const response = await postBjNickname(form.bjNickname);
 
       if (response.ok) {
         showToast("등록이 완료되었습니다", "success");


### PR DESCRIPTION
## ✅ Done Task
  - [x] 토큰 교체 서버액션 로직 정상화
  - [x] 토큰 교체 ky hook 로직 수정
  - [x] 공지 글 작성 즉시 갱신되도록 수정 fe-68

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
- 원인 요약
1. 모종의 이유로 `reIssueAction()`을 통해 토큰이 교체됨
(원래는 액션이 사용될 일 없이 `RefreshTokenExpireTime`으로 잘 교체되어야 함)

2. 그러나 `reIssueAction()` 로직에 문제가 있어서 세션 데이터의 access token은 갱신되지 않음
(**갱신되지 않은 세션 데이터의 access token은 만료되어 교체 불가능 상태**)
(클라이언트 측 내부 access token 저장소를 사용하므로 새로고침 전까지 api 호출 자체는 문제 없음)
(새로고침 시 갱신되지 않은 세션 데이터 access token을 사용)

3. 나중에 다시 접속했을 때 클라이언트에서 1분마다 토큰 만료를 검사하는 `RefreshTokenExpireTime` 작동
→ 교체 불가능이므로 403에러 및 서버용 `signOut()` 호출

4. 이후 제일 먼저 호출하는 api인 `notification` api 호출
→ ky의 before retry hook에서 403에러를 만나서 별다른 처리 없이 retry 2회 후 클라용 `signOut()` 호출

5. 둘이 겹치면서 리다이렉트가 엉킨건지.. 정확히는 확인 못하겠으나 .env의 `AUTH_URL` 이 없어 기본 설정된 리다이렉트 주소인 localhost로 이동해버림!

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
먼저 `reIssueAction()` 로직에 어떤 문제가 있었는지 설명하겠습니다. 
기존 토큰 교체 로직은 2가지 루트로 이루어졌습니다.
1. 60초마다 access token 만료 5분 전인지 확인 후 교체
    ```typescript
    // setInterval( )로 1분마다 확인하여 교체하는 함수
    const watchAndUpdateIfExpire = async () => {
      // ...
          // update 함수로 auth.ts의 jwt 및 session 콜백 호출
          const newSession = await update(await getSession());
          setAccessToken(newSession?.accessToken!);
      // ...
    };
    ```
    
    ```typescript
    // auth.ts의 jwt 콜백
    else if (trigger === "update") {
      if (token.accessTokenExpires - Date.now() < 1000 * 60 * 5) {
        const { accessToken, refreshToken } = await postReissueToken({
          expiredAccessToken: token.accessToken,
          refreshToken: token.refreshToken,
        });
        token.accessToken = accessToken;
        token.refreshToken = refreshToken;
        token.accessTokenExpires = jwtDecode(accessToken).exp! * 1000;
      }
      token.user = (await getMyInfo(token.accessToken)) as AdapterUser;
    }
    // session 콜백은 단순히 token값 복사하는 역할
    ```
    1번 로직은 New Insight에서 설명한 대로 아무 문제 없이 잘 작동합니다.
    1분마다 토큰 만료 5분 전인지 확인하여 jwt 콜백의 `trigger === update` 분기에 들어가 잘 교체하고 마무리 됩니다.

2. 토큰이 필요한 api 요청 시 4xx로 거절 당하면 교체
    ```typescript
    // ky hook
    const insertNewToken: BeforeRetryHook = async ({
      error,
      request,
      retryCount,
    }) => {
      // 2회 응답 거부 시, 로그아웃 및 api 요청 중지
      if (retryCount === 2) {
        if (isServer) {
          await signOut();
        } else {
          await cSignOut();
          setAccessToken("");
        }
        ky.stop;
        return;
      }
      // 인가를 못 받았으면 reIssueAction( ) 호출
      const { response } = error as HTTPError;
      if (
        response?.status === HTTP_ERROR_STATUS.UNAUTHORIZED ||
        error.message === "Failed to fetch"
      ) {
        const newAccessToken = (await reIssueAction())?.accessToken;
        typeof window !== "undefined" && setAccessToken(newAccessToken);
        request.headers.set("Authorization", `Bearer ${newAccessToken}`);
      }
    };
    ```

    ```typescript
    // 토큰 교체 서버액션
    export const reIssueAction = async () => {
      // ...
      const newTokens = await postReissueToken({
        expiredAccessToken,
        refreshToken,
      });
      await update({
        ...session,
        ...newTokens,
      });
  
      return newTokens;
    ```
    여기서 update 함수를 잘 보면 토큰만 삽입하고 `accessTokenExpires`는 갱신하지 않는 것을 볼 수 있습니다.
    그 결과 `auth.ts`의 jwt 콜백에서 `if (token.accessTokenExpires - Date.now() < 1000 * 60 * 5)`는 첫 로그인 후 25분이 지났다면 조건 없이 true가 되고, 토큰을 교체하려고 시도합니다. 정상적으로 작동했다면 이는 `postReIssueToken`을 2회 시행하고 말겠지만, jwt콜백에서 하나 더 잘못된 코드가 있었습니다.
    ```typescript
    async jwt({ token, user, trigger, session/* 기존에 안 쓰던 객체 */ }) { ... }
    ```
    jwt 콜백에서 사용할 수 있는 매개변수들인데, token과 session의 차이는 다음과 같습니다.
    - token : next.js 서버에만 존재하는 내부 세션 데이터, `update()` 함수와는 관계없이 jwt 콜백에서만 변경 가능
    - session : 사용자에게 전송되어 사용자가 실제로 사용하는 세션 데이터, **`update()` 함수의 인자가 session 객체임**
  
    기존 코드에서는 token만 가지고 토큰 교체를 진행했었습니다. 그 결과 `await update({...session,...newTokens,});`을 했음에도 `if (token.accessTokenExpires - Date.now() < 1000 * 60 * 5)` 이후의 코드에서 새 토큰이 아닌 `reIssueToken`에 사용한 구 토큰을 사용하게 되어 에러가 발생합니다.
    
이상의 이유로 `reIssueAction()`을 사용한 토큰 교체 로직이 문제가 되어 이상한 리다이렉트를 일으키고 말았던 걸로 확인되었습니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->