### PR TITLE
[ Feat ] 비밀번호 일치 캡션

### DIFF
--- a/src/shared/util/form.ts
+++ b/src/shared/util/form.ts
@@ -1,3 +1,5 @@
+import type { baseSignupSchema } from "@/view/signup/AccountRegister/schema";
+import { defaultSignupMsg } from "@/view/signup/AccountRegister/useSignupForm";
 import type { ChangeEvent } from "react";
 import type {
   ControllerRenderProps,
@@ -112,4 +114,59 @@ export const createFormDataFromDirtyFields = <T extends z.ZodRawShape>(
     JSON.stringify({ ...requestData, ...withoutImageField }),
   );
   return data;
+};
+
+export const getPasswordValidation = (
+  form: UseFormReturn<z.infer<typeof baseSignupSchema>>,
+) => {
+  const { errors } = form.formState;
+  const [password, confirmPassword] = form.watch([
+    "password",
+    "confirmPassword",
+  ]);
+
+  const passwordError =
+    !!errors.password || errors.confirmPassword?.type === "custom";
+  const isPasswordMatch = Boolean(
+    password && confirmPassword && password === confirmPassword,
+  );
+  const passwordMsg =
+    errors.confirmPassword?.message ||
+    (isPasswordMatch
+      ? defaultSignupMsg.validPassword
+      : defaultSignupMsg.password);
+
+  return {
+    passwordError,
+    isPasswordMatch,
+    passwordMsg,
+  };
+};
+
+export const getNicknameValidation = (
+  form: UseFormReturn<z.infer<typeof baseSignupSchema>>,
+  isNicknameLoading: boolean,
+) => {
+  const {
+    errors: { nickname: nicknameError },
+    dirtyFields: { nickname: nicknameDirty },
+    isValid,
+  } = form.formState;
+
+  const isNicknameValid = Boolean(
+    !(nicknameError || isNicknameLoading) && nicknameDirty,
+  );
+
+  const nicknameMsg = (() => {
+    if (isNicknameLoading) return defaultSignupMsg.nicknameLoading;
+    if (isNicknameValid) return defaultSignupMsg.validNickname;
+    return nicknameError?.message ?? defaultSignupMsg.nickname;
+  })();
+
+  const isActive = !isNicknameLoading && isValid;
+
+  return {
+    nicknameMsg,
+    isActive,
+  };
 };

--- a/src/view/signup/AccountRegister/PasswordSetup.tsx
+++ b/src/view/signup/AccountRegister/PasswordSetup.tsx
@@ -1,47 +1,27 @@
 import Button from "@/common/component/Button";
 import { FormController } from "@/shared/component/Form";
-import { getMultipleRevalidationHandlers } from "@/shared/util/form";
+import {
+  getMultipleRevalidationHandlers,
+  getPasswordValidation,
+} from "@/shared/util/form";
 import clsx from "clsx";
 import type { UseFormReturn } from "react-hook-form";
+import type { z } from "zod";
 import {
   descriptionStyle,
   formContainer,
   passwordMatchStyle,
 } from "../SignupForm/index.css";
-import { defaultSignupMsg } from "./useSignupForm";
+import type { baseSignupSchema } from "./schema";
 
 type PasswordSetupProps = {
   onNextStep: () => void;
-  form: UseFormReturn<
-    {
-      password: string;
-      confirmPassword: string;
-      nickname: string;
-      profile: string | File | null;
-    },
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-    any,
-    undefined
-  >;
+  form: UseFormReturn<z.infer<typeof baseSignupSchema>>;
 };
 
 const PasswordSetup = ({ onNextStep, form }: PasswordSetupProps) => {
-  const { errors } = form.formState;
-  const passwordError =
-    !!errors.password || errors.confirmPassword?.type === "custom";
-
-  const [password, confirmPassword] = form.watch([
-    "password",
-    "confirmPassword",
-  ]);
-  const isPasswordMatch =
-    password && confirmPassword && password === confirmPassword;
-
-  const passwordMsg =
-    errors.confirmPassword?.message ||
-    (isPasswordMatch
-      ? defaultSignupMsg.validPassword
-      : defaultSignupMsg.password);
+  const { passwordError, isPasswordMatch, passwordMsg } =
+    getPasswordValidation(form);
 
   return (
     <>
@@ -84,11 +64,13 @@ const PasswordSetup = ({ onNextStep, form }: PasswordSetupProps) => {
           }}
         />
       </div>
+      {/* step형식이므로 이 단계에서 submit 금지 */}
       <Button
         style={{ marginTop: "4rem" }}
         type="button"
         size="large"
         onClick={onNextStep}
+        isActive={isPasswordMatch}
       >
         다음
       </Button>

--- a/src/view/signup/AccountRegister/PasswordSetup.tsx
+++ b/src/view/signup/AccountRegister/PasswordSetup.tsx
@@ -1,8 +1,14 @@
 import Button from "@/common/component/Button";
 import { FormController } from "@/shared/component/Form";
 import { getMultipleRevalidationHandlers } from "@/shared/util/form";
+import clsx from "clsx";
 import type { UseFormReturn } from "react-hook-form";
-import { descriptionStyle, formContainer } from "../SignupForm/index.css";
+import {
+  descriptionStyle,
+  formContainer,
+  passwordMatchStyle,
+} from "../SignupForm/index.css";
+import { defaultSignupMsg } from "./useSignupForm";
 
 type PasswordSetupProps = {
   passwordError: boolean;
@@ -27,6 +33,7 @@ const PasswordSetup = ({
   onNextStep,
   form,
 }: PasswordSetupProps) => {
+  const isPasswordMatch = defaultSignupMsg.validPassword === passwordMsg;
   return (
     <>
       <div className={formContainer}>
@@ -58,7 +65,10 @@ const PasswordSetup = ({
             id: "password-description",
             isError: passwordError,
             message: passwordMsg,
-            className: descriptionStyle,
+            className: clsx(
+              descriptionStyle,
+              isPasswordMatch && passwordMatchStyle,
+            ),
           }}
         />
       </div>

--- a/src/view/signup/AccountRegister/PasswordSetup.tsx
+++ b/src/view/signup/AccountRegister/PasswordSetup.tsx
@@ -11,8 +11,6 @@ import {
 import { defaultSignupMsg } from "./useSignupForm";
 
 type PasswordSetupProps = {
-  passwordError: boolean;
-  passwordMsg: string;
   onNextStep: () => void;
   form: UseFormReturn<
     {
@@ -27,13 +25,24 @@ type PasswordSetupProps = {
   >;
 };
 
-const PasswordSetup = ({
-  passwordError,
-  passwordMsg,
-  onNextStep,
-  form,
-}: PasswordSetupProps) => {
-  const isPasswordMatch = defaultSignupMsg.validPassword === passwordMsg;
+const PasswordSetup = ({ onNextStep, form }: PasswordSetupProps) => {
+  const { errors } = form.formState;
+  const passwordError =
+    !!errors.password || errors.confirmPassword?.type === "custom";
+
+  const [password, confirmPassword] = form.watch([
+    "password",
+    "confirmPassword",
+  ]);
+  const isPasswordMatch =
+    password && confirmPassword && password === confirmPassword;
+
+  const passwordMsg =
+    errors.confirmPassword?.message ||
+    (isPasswordMatch
+      ? defaultSignupMsg.validPassword
+      : defaultSignupMsg.password);
+
   return (
     <>
       <div className={formContainer}>
@@ -41,6 +50,9 @@ const PasswordSetup = ({
           form={form}
           name="password"
           type="input"
+          revalidationHandlers={getMultipleRevalidationHandlers(
+            "confirmPassword",
+          )}
           fieldProps={{
             placeholder: "비밀번호",
             type: "password",

--- a/src/view/signup/AccountRegister/ProfileCreation.tsx
+++ b/src/view/signup/AccountRegister/ProfileCreation.tsx
@@ -1,11 +1,12 @@
 import Button from "@/common/component/Button";
 import { FormController } from "@/shared/component/Form";
+import { useCheckOnServer } from "@/shared/hook/useCheckOnServer";
 import { handleOnChangeMode } from "@/shared/util/form";
 import { controllerStyle, formContainer } from "@/view/signup/index.css";
 import type { UseFormReturn } from "react-hook-form";
+import { defaultSignupMsg } from "./useSignupForm";
 
 type ProfileCreationProps = {
-  isActive: boolean;
   form: UseFormReturn<
     {
       password: string;
@@ -17,14 +18,25 @@ type ProfileCreationProps = {
     any,
     undefined
   >;
-  nicknameMsg: string;
 };
 
-const ProfileCreation = ({
-  isActive,
-  form,
-  nicknameMsg,
-}: ProfileCreationProps) => {
+const ProfileCreation = ({ form }: ProfileCreationProps) => {
+  const nickname = form.watch("nickname");
+
+  const { isNicknameLoading } = useCheckOnServer(form, nickname);
+  const { isValid, errors, dirtyFields } = form.formState;
+
+  const showNicknameMsg =
+    !(errors.nickname || isNicknameLoading) && dirtyFields.nickname;
+
+  const nicknameMsg = isNicknameLoading
+    ? defaultSignupMsg.nicknameLoading
+    : showNicknameMsg
+      ? defaultSignupMsg.validNickname
+      : errors.nickname?.message || defaultSignupMsg.nickname;
+
+  const isActive = isValid && !isNicknameLoading;
+
   return (
     <>
       <div className={formContainer}>

--- a/src/view/signup/AccountRegister/ProfileCreation.tsx
+++ b/src/view/signup/AccountRegister/ProfileCreation.tsx
@@ -1,42 +1,24 @@
 import Button from "@/common/component/Button";
 import { FormController } from "@/shared/component/Form";
 import { useCheckOnServer } from "@/shared/hook/useCheckOnServer";
-import { handleOnChangeMode } from "@/shared/util/form";
+import { getNicknameValidation, handleOnChangeMode } from "@/shared/util/form";
 import { controllerStyle, formContainer } from "@/view/signup/index.css";
 import type { UseFormReturn } from "react-hook-form";
-import { defaultSignupMsg } from "./useSignupForm";
+import type { z } from "zod";
+import type { baseSignupSchema } from "./schema";
 
 type ProfileCreationProps = {
-  form: UseFormReturn<
-    {
-      password: string;
-      confirmPassword: string;
-      nickname: string;
-      profile: string | File | null;
-    },
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-    any,
-    undefined
-  >;
+  form: UseFormReturn<z.infer<typeof baseSignupSchema>>;
 };
 
 const ProfileCreation = ({ form }: ProfileCreationProps) => {
   const nickname = form.watch("nickname");
 
   const { isNicknameLoading } = useCheckOnServer(form, nickname);
-  const { isValid, errors, dirtyFields } = form.formState;
-
-  const showNicknameMsg =
-    !(errors.nickname || isNicknameLoading) && dirtyFields.nickname;
-
-  const nicknameMsg = isNicknameLoading
-    ? defaultSignupMsg.nicknameLoading
-    : showNicknameMsg
-      ? defaultSignupMsg.validNickname
-      : errors.nickname?.message || defaultSignupMsg.nickname;
-
-  const isActive = isValid && !isNicknameLoading;
-
+  const { isActive, nicknameMsg } = getNicknameValidation(
+    form,
+    isNicknameLoading,
+  );
   return (
     <>
       <div className={formContainer}>

--- a/src/view/signup/AccountRegister/index.tsx
+++ b/src/view/signup/AccountRegister/index.tsx
@@ -9,11 +9,11 @@ import ProfileCreation from "./ProfileCreation";
 import useSignupForm from "./useSignupForm";
 
 const AccountRegister = ({ token }: { token: string }) => {
-  const { form, handleSubmit } = useSignupForm(token);
-
+  const { form, _handleSubmit } = useSignupForm();
   const [step, setStep] = useState(SIGNUP_STEPS.PASSWORD_SETUP);
-  const handleNextStep = () => setStep(SIGNUP_STEPS.PROFILE_CREATION);
 
+  const handleNextStep = () => setStep(SIGNUP_STEPS.PROFILE_CREATION);
+  const handleSubmit = _handleSubmit.bind(this, token);
   return (
     <div>
       <Stepper

--- a/src/view/signup/AccountRegister/index.tsx
+++ b/src/view/signup/AccountRegister/index.tsx
@@ -1,10 +1,7 @@
 "use client";
-import { signUpAction } from "@/app/api/auth/actions";
 import { Form } from "@/shared/component/Form";
-import type { signupSchema } from "@/view/signup/AccountRegister/schema";
 import { containerStyle } from "@/view/signup/index.css";
 import { useState } from "react";
-import type { z } from "zod";
 import Stepper from "../Stepper";
 import { SIGNUP_STEPS } from "../constant";
 import PasswordSetup from "./PasswordSetup";
@@ -12,29 +9,10 @@ import ProfileCreation from "./ProfileCreation";
 import useSignupForm from "./useSignupForm";
 
 const AccountRegister = ({ token }: { token: string }) => {
+  const { form, handleSubmit } = useSignupForm(token);
+
   const [step, setStep] = useState(SIGNUP_STEPS.PASSWORD_SETUP);
-  const { form, passwordError, passwordMsg, nicknameMsg, isActive } =
-    useSignupForm();
-
   const handleNextStep = () => setStep(SIGNUP_STEPS.PROFILE_CREATION);
-
-  const handleSubmit = async (values: z.infer<typeof signupSchema>) => {
-    const data = new FormData();
-
-    if (values.profile) {
-      data.append("profileImage", values.profile);
-    }
-
-    data.append(
-      "request",
-      JSON.stringify({
-        password: values.password,
-        nickname: values.nickname,
-      }),
-    );
-
-    await signUpAction(token, data);
-  };
 
   return (
     <div>
@@ -48,18 +26,9 @@ const AccountRegister = ({ token }: { token: string }) => {
           className={containerStyle}
         >
           {step === SIGNUP_STEPS.PASSWORD_SETUP ? (
-            <PasswordSetup
-              form={form}
-              passwordError={passwordError}
-              passwordMsg={passwordMsg}
-              onNextStep={handleNextStep}
-            />
+            <PasswordSetup form={form} onNextStep={handleNextStep} />
           ) : (
-            <ProfileCreation
-              isActive={isActive}
-              form={form}
-              nicknameMsg={nicknameMsg}
-            />
+            <ProfileCreation form={form} />
           )}
         </form>
       </Form>

--- a/src/view/signup/AccountRegister/schema.ts
+++ b/src/view/signup/AccountRegister/schema.ts
@@ -18,7 +18,13 @@ export const baseSignupSchema = z.object({
 });
 
 export const signupSchema = baseSignupSchema.refine(
-  (data) => data.password === data.confirmPassword,
+  (data) => {
+    const { password, confirmPassword } = data;
+    if (password.length < 8) return true;
+
+    // 현재까지 입력된 부분이 일치하는지 확인
+    return password.startsWith(confirmPassword);
+  },
   {
     message: "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
     path: ["confirmPassword"],

--- a/src/view/signup/AccountRegister/useSignupForm.ts
+++ b/src/view/signup/AccountRegister/useSignupForm.ts
@@ -4,10 +4,11 @@ import { useForm } from "react-hook-form";
 import type { z } from "zod";
 import { signupSchema } from "./schema";
 
-const defaultMsg = {
+export const defaultSignupMsg = {
   password: "영문, 숫자, 특수문자(~!@#$%^&*) 조합 8~15 자리",
   nickname: "15자리 이내, 문자/숫자 가능, 특수문자/기호 입력 불가",
   validNickname: "사용가능한 닉네임이에요.",
+  validPassword: "비밀번호가 일치합니다.",
   nicknameLoading: "로딩중",
 };
 
@@ -31,16 +32,25 @@ const useSignupForm = () => {
   const passwordError =
     !!errors.password || errors.confirmPassword?.type === "custom";
 
-  const passwordMsg = errors.confirmPassword?.message || defaultMsg.password;
+  const password = form.watch("password");
+  const confirmPassword = form.watch("confirmPassword");
+  const isPasswordMatch =
+    password && confirmPassword && password === confirmPassword;
+
+  const passwordMsg =
+    errors.confirmPassword?.message ||
+    (isPasswordMatch
+      ? defaultSignupMsg.validPassword
+      : defaultSignupMsg.password);
 
   const showNicknameMsg =
     !(errors.nickname || isNicknameLoading) && dirtyFields.nickname;
 
   const nicknameMsg = isNicknameLoading
-    ? defaultMsg.nicknameLoading
+    ? defaultSignupMsg.nicknameLoading
     : showNicknameMsg
-      ? defaultMsg.validNickname
-      : errors.nickname?.message || defaultMsg.nickname;
+      ? defaultSignupMsg.validNickname
+      : errors.nickname?.message || defaultSignupMsg.nickname;
 
   const isActive = isValid && !isNicknameLoading;
 

--- a/src/view/signup/AccountRegister/useSignupForm.ts
+++ b/src/view/signup/AccountRegister/useSignupForm.ts
@@ -12,7 +12,7 @@ export const defaultSignupMsg = {
   nicknameLoading: "로딩중",
 };
 
-const useSignupForm = (token: string) => {
+const useSignupForm = () => {
   const form = useForm<z.infer<typeof signupSchema>>({
     resolver: zodResolver(signupSchema),
     mode: "onTouched",
@@ -24,7 +24,10 @@ const useSignupForm = (token: string) => {
     },
   });
 
-  const handleSubmit = async (values: z.infer<typeof signupSchema>) => {
+  const _handleSubmit = async (
+    token: string,
+    values: z.infer<typeof signupSchema>,
+  ) => {
     const data = new FormData();
 
     if (values.profile) {
@@ -44,7 +47,7 @@ const useSignupForm = (token: string) => {
 
   return {
     form,
-    handleSubmit,
+    _handleSubmit,
   };
 };
 

--- a/src/view/signup/SignupForm/index.css.ts
+++ b/src/view/signup/SignupForm/index.css.ts
@@ -1,3 +1,4 @@
+import { theme } from "@/styles/themes.css";
 import { style } from "@vanilla-extract/css";
 
 export const formStyle = style({
@@ -27,4 +28,9 @@ export const formContainer = style({
 
 export const descriptionStyle = style({
   paddingBottom: "0.5rem",
+});
+
+export const passwordMatchStyle = style({
+  ...theme.font.Caption3_M_12,
+  color: theme.color.yellow,
 });


### PR DESCRIPTION
## ✅ Done Task
  - [x] signup 페이지에서 비밀번호 일치 시 캡션 표시
  - [x] 폼 관심사 분리
  - [x] 편의성 향상

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 관심사 분리
비밀번호 & 닉네임 관련 캡션이나 서버 검증 등 모든걸 `useSignupForm` 훅에서 처리하기 보다는 step 형식으로 컴포넌트를 따로 렌더링하는 현 구조에 맞게 각 컴포넌트에서 자신이 사용할 값들만 처리하도록 관심사를 분리했습니다.

- 사용법 리마인드
`revalidationHandlers={getMultipleRevalidationHandlers("password")}`이 코드는 다수의 폼 요소를 한번에 검사할 수 있게하는 prop입니다. 보통 비밀번호 & 확인에서 사용하는데, **대상이 되는 요소에 다 적용**해야 합니다. 그렇지 않을 경우 password 입력 후 confirm 매치 시에는 의도한대로 적용되나 그 반대 순서로 입력할 때 비밀번호 일치 캡션이 나오지 않는 등 양방향 검증이 되지 않아 의도하지 않은 버그가 발생할 수 있습니다.

- (추가) 편의성 향상
저번에 적용했었던 비밀번호 일치 검사와 관련한 편의성 기능을 적용했습니다. 입력을 하자마자 바로 에러메세지가 뜨면 불-편한 기분이 들기 때문에, 다음 기준을 적용하여 적절한 시기에 에러메세지가 뜨도록 했습니다.
  1. 작성중인 password 길이 : password를 처음 입력할때나 confirm부터 작성할 경우 미일치 메세지가 뜨기에 schema 기준 최소값인 8자 이상부터 검사
  2. 일치 확인 실시간 검사 : `password.startWith` 메서드로 동일한 문자열을 작성하고 있는지 검사

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
![SmartSelect_20250517_191343_Chrome](https://github.com/user-attachments/assets/78474b1c-b765-4f22-b19d-d21813f3db17)
