### PR TITLE
[ Fix ] 보안규칙 수 한도에 의한 배포 실패

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -130,3 +130,9 @@ jobs:
             cd algohub
             pnpm install --frozen-lockfile
             pm2 start pnpm --name algohub -- start
+
+      - name: Remove Github Actions IP from Security group
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name ${{ env.AWS_SG_NAME }} --protocol tcp --port ${{ secrets.AWS_SSH_PORT }} --cidr ${{ steps.ip.outputs.ipv4 }}/32
+        


### PR DESCRIPTION
## ✅ Done Task
  - [x] 규칙 제거 명령어 추가

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
linear 이슈 내용 참고해주세요.
규칙 제거는 모든 작업이 완료된 후 실시하며, 배포 실패시에도 규칙을 제거하도록 했으니 이번에만 2회 action을 돌려야 배포가 될겁니다!는 서버분이 해결..
## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->