### PR TITLE
[Fix] 무한루프 발생 가능성 확인

### DIFF
--- a/apps/client/src/app/api/index.ts
+++ b/apps/client/src/app/api/index.ts
@@ -32,10 +32,7 @@ const insertNewToken: BeforeRetryHook = async ({
   request,
   retryCount,
 }) => {
-  if (retryCount === 2) {
-    ky.stop;
-    return;
-  }
+  if (retryCount === 2) throw ky.stop;
   const { response } = error as HTTPError;
   if (
     response?.status === HTTP_ERROR_STATUS.UNAUTHORIZED ||
@@ -48,8 +45,7 @@ const insertNewToken: BeforeRetryHook = async ({
       request.headers.set("Authorization", `Bearer ${reIssueData}`);
     } else if (reIssueData.status !== 500) {
       await logoutAction();
-      ky.stop;
-      return;
+      throw ky.stop;
     }
   }
 };

--- a/apps/client/src/app/provider.tsx
+++ b/apps/client/src/app/provider.tsx
@@ -8,7 +8,7 @@ import RefreshTokenExpireTime from "@/shared/component/RefreshTokenExpireTime";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
-import { useEffect, type ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 
 const BrowserProvider = dynamic(
   () => import("@/shared/component/BrowserProvider/BrowserProvider"),

--- a/apps/client/src/app/provider.tsx
+++ b/apps/client/src/app/provider.tsx
@@ -8,7 +8,7 @@ import RefreshTokenExpireTime from "@/shared/component/RefreshTokenExpireTime";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 
 const BrowserProvider = dynamic(
   () => import("@/shared/component/BrowserProvider/BrowserProvider"),
@@ -25,12 +25,14 @@ const Providers = ({ children }: ProvidersProps) => {
   const { data: session, update } = useSession();
   const { id, email, nickname, bjNickname } = session?.user ?? {};
 
-  mixpanelTracker.initialize({
-    $email: email ?? "",
-    $name: nickname ?? "",
-    id,
-    bjNickname,
-  });
+  useEffect(() => {
+    mixpanelTracker.initialize({
+      $email: email ?? "",
+      $name: nickname ?? "",
+      id,
+      bjNickname,
+    });
+  }, [email, nickname, id, bjNickname]);
 
   return (
     <QueryProvider>

--- a/apps/client/src/shared/component/RefreshTokenExpireTime/index.tsx
+++ b/apps/client/src/shared/component/RefreshTokenExpireTime/index.tsx
@@ -3,6 +3,7 @@
 import type { Session } from "next-auth";
 import { useEffect, useRef } from "react";
 import { setAccessToken } from "../../util/token";
+import { getSession } from "next-auth/react";
 
 const RefreshTokenExpireTime = ({
   session,
@@ -16,7 +17,7 @@ const RefreshTokenExpireTime = ({
     if (session) {
       const timeRemaining = session.accessTokenExpires - Date.now();
       if (timeRemaining <= 1000 * 60 * 5) {
-        const newSession = await update();
+        const newSession = await update(await getSession());
         setAccessToken(newSession?.accessToken!);
       }
     }

--- a/apps/client/src/shared/component/RefreshTokenExpireTime/index.tsx
+++ b/apps/client/src/shared/component/RefreshTokenExpireTime/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import type { Session } from "next-auth";
+import { getSession } from "next-auth/react";
 import { useEffect, useRef } from "react";
 import { setAccessToken } from "../../util/token";
-import { getSession } from "next-auth/react";
 
 const RefreshTokenExpireTime = ({
   session,

--- a/apps/client/src/shared/component/RefreshTokenExpireTime/index.tsx
+++ b/apps/client/src/shared/component/RefreshTokenExpireTime/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { Session } from "next-auth";
-import { getSession } from "next-auth/react";
 import { useEffect, useRef } from "react";
 import { setAccessToken } from "../../util/token";
 
@@ -17,7 +16,7 @@ const RefreshTokenExpireTime = ({
     if (session) {
       const timeRemaining = session.accessTokenExpires - Date.now();
       if (timeRemaining <= 1000 * 60 * 5) {
-        const newSession = await update(await getSession());
+        const newSession = await update();
         setAccessToken(newSession?.accessToken!);
       }
     }
@@ -27,7 +26,6 @@ const RefreshTokenExpireTime = ({
     if (interval.current) {
       clearInterval(interval.current);
     }
-    watchAndUpdateIfExpire();
     interval.current = setInterval(watchAndUpdateIfExpire, 1000 * 60);
 
     return () => clearInterval(interval.current);

--- a/apps/client/src/shared/component/RefreshTokenExpireTime/index.tsx
+++ b/apps/client/src/shared/component/RefreshTokenExpireTime/index.tsx
@@ -23,6 +23,10 @@ const RefreshTokenExpireTime = ({
   };
 
   useEffect(() => {
+    watchAndUpdateIfExpire();
+  }, []);
+
+  useEffect(() => {
     if (interval.current) {
       clearInterval(interval.current);
     }


### PR DESCRIPTION
## ✅ Done Task
  - [x] 무한루프 발생 가능성 확인

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

### RefreshTokenExpireTime 로직

```ts
  useEffect(() => {
    if (interval.current) {
      clearInterval(interval.current);
    }
    watchAndUpdateIfExpire();
    interval.current = setInterval(watchAndUpdateIfExpire, 1000 * 60);

    return () => clearInterval(interval.current);
  }, [session?.accessToken]);
```

기존 로직은 위와 같습니다
이 `useEffect` 는 session이 변경될 때마다 실행되고,
`useEffect` 내부에서는 `watchAndUpdateIfExpire` 함수가 즉시 호출됩니다
해당 함수에서는 `update()` 함수가 호출되면서 세션이 갱신되는데
이로인해 다시 `useEffect` 가 호출되게 됩니다
위 과정이 반복되면서 무한루프가 발생했을 수도 있을 것 같아 즉시 호출되는 함수 부분을 삭제하였습니다

### mixpanelTracker 초기화 로직

`mixpanelTracker.initialize` 함수가 `Providers` 컴포넌트 렌더링될 때마다 호출됩니다
이에 첫 마운트될 때만 호출될 수 있도록 `useEffect`로 감싸주었습니다

### api retry 로직
`ky.stop` 을 통해 ky instance의 api 호출을 중지할 수 있는데, gpt가 잘못 알려줘서 그동안 이상하게 쓰고 있었네요. 
그동안 react hook form처럼 ky.stop을 접근하면 proxy를 통해 api를 중지하는 로직이 실행되나 했었는데, 그냥 return이나 throw를 해 주어야 되더라고요. 

잘못 사용했던 까닭에 api 호출을 실패하여 retry를 계속 진행해도 ky.stop으로 중지될 일 없이 무한 retry를 진행하는 버그가 발생했었습니다. 보통은 `logoutAction()`으로 페이지 자체가 redirect되어 정상적으로 로그인 상태가 해제되긴 하나, 그렇지 못하고 무한루프에 빠지는 경우도 발생했었습니다.

근데 이게 cpu load 100%를 유발하는 주요 버그는 아닐 것 같아요.