### PR TITLE
[ Refactor ] 문제 풀이 모달에서 히스토리 없을시 풀이 리스트로 리다이렉트

### DIFF
--- a/apps/client/src/app/api/solutions/type.ts
+++ b/apps/client/src/app/api/solutions/type.ts
@@ -11,6 +11,7 @@ export type SolutionRequest = {
 
 export type SolutionContent = {
   solutionId: number;
+  problemId: number;
   problemTitle: string;
   problemLevel: number;
   accuracy: number;

--- a/apps/client/src/app/group/[groupId]/my-solved/components/SolvedItem/SolvedItem.stories.tsx
+++ b/apps/client/src/app/group/[groupId]/my-solved/components/SolvedItem/SolvedItem.stories.tsx
@@ -18,6 +18,7 @@ export const Default = {
     const data: SolutionContent[] = [
       {
         solutionId: 1,
+        problemId: 1,
         problemTitle: "막대기",
         problemLevel: 6,
         accuracy: 100,
@@ -37,6 +38,7 @@ export const Default = {
       },
       {
         solutionId: 1,
+        problemId: 1,
         problemTitle: "막대기",
         problemLevel: 6,
         accuracy: 100,
@@ -56,6 +58,7 @@ export const Default = {
       },
       {
         solutionId: 1,
+        problemId: 1,
         problemTitle: "막대기",
         problemLevel: 6,
         accuracy: 100,
@@ -75,6 +78,7 @@ export const Default = {
       },
       {
         solutionId: 1,
+        problemId: 1,
         problemTitle: "막대기",
         problemLevel: 6,
         accuracy: 100,

--- a/apps/client/src/app/group/[groupId]/solved-detail/[id]/page.tsx
+++ b/apps/client/src/app/group/[groupId]/solved-detail/[id]/page.tsx
@@ -33,7 +33,9 @@ const page = ({ params }: { params: { id: string; groupId: string } }) => {
     if (window.history.length > 1) {
       router.back();
     } else {
-      router.push(`/group/${params.groupId}/my-solved`);
+      router.replace(
+        `/group/${params.groupId}/problem-list/${solutionInfo.problemId}`,
+      );
     }
   };
 

--- a/apps/client/src/app/group/[groupId]/solved-detail/[id]/page.tsx
+++ b/apps/client/src/app/group/[groupId]/solved-detail/[id]/page.tsx
@@ -13,7 +13,7 @@ import { usePvEvent } from "@/shared/hook/usePvEvent";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 
-const page = ({ params }: { params: { id: string } }) => {
+const page = ({ params }: { params: { id: string; groupId: string } }) => {
   const router = useRouter();
   const routeParams = useParams();
   const groupId = Array.isArray(routeParams.groupId)
@@ -29,8 +29,16 @@ const page = ({ params }: { params: { id: string } }) => {
 
   if (!solutionInfo) return null;
 
+  const handleCloseClick = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(`/group/${params.groupId}/my-solved`);
+    }
+  };
+
   return (
-    <Modal isOpen={true} onClose={() => router.back()} hasCloseBtn>
+    <Modal isOpen={true} onClose={handleCloseClick} hasCloseBtn>
       <div className={modalWrapper}>
         <header>
           <SolvedDetail info={solutionInfo} />


### PR DESCRIPTION
## ✅ Done Task
  - [x] To-do

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
   
## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
`window.history.length` 를 사용하여 브라우저 히스토리가 1개 이하인 경우(이전 페이지가 없는 경우) 풀이 리스트로 리다이렉트 시켜주었어요.
다른 방법이 떠오르지 않아서 이렇게 우선 구현했는데 혹시 다른 방법 추천해주실거  있으면 코멘트 남겨주세요!

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

### redirect url 변경

https://github.com/user-attachments/assets/fbc10213-364d-4337-8f8f-11f7ff87332d


