### PR TITLE
[ Feat ] 풀이 현황 테이블 구현

### DIFF
--- a/apps/client/src/app/api/groups/index.ts
+++ b/apps/client/src/app/api/groups/index.ts
@@ -14,7 +14,6 @@ import type {
 } from "@/app/api/notices/type";
 import type {
   GetProblemRequest,
-  ProblemContent,
   ProblemListResponse,
   ProblemRequest,
 } from "@/app/api/problems/type";
@@ -235,14 +234,6 @@ export const postGroupNotice = (
 export const postProblem = (groupId: number, body: ProblemRequest) => {
   const response = kyJsonWithTokenInstance
     .post(`api/groups/${groupId}/problems`, { json: body })
-    .json();
-
-  return response;
-};
-
-export const getDeadlineReachedProblems = async (groupId: number) => {
-  const response = await kyJsonWithTokenInstance
-    .get<ProblemContent[]>(`api/groups/${groupId}/problems/deadline-reached`)
     .json();
 
   return response;

--- a/apps/client/src/app/api/solutions/index.ts
+++ b/apps/client/src/app/api/solutions/index.ts
@@ -4,7 +4,7 @@ import type {
   SolutionRequest,
   SolutionResponse,
 } from "@/app/api/solutions/type";
-import { SolutionsCurrentStatusResponse } from "@/app/api/type";
+import type { SolutionsCurrentStatusResponse } from "@/app/api/type";
 
 export const getSolutionList = async ({
   problemId,

--- a/apps/client/src/app/api/solutions/index.ts
+++ b/apps/client/src/app/api/solutions/index.ts
@@ -4,6 +4,7 @@ import type {
   SolutionRequest,
   SolutionResponse,
 } from "@/app/api/solutions/type";
+import { SolutionsCurrentStatusResponse } from "@/app/api/type";
 
 export const getSolutionList = async ({
   problemId,
@@ -27,6 +28,16 @@ export const getSolutionList = async ({
 export const getSolution = async (solutionId: number) => {
   const response = await kyJsonWithTokenInstance
     .get<SolutionContent>(`api/solutions/${solutionId}`)
+    .json();
+
+  return response;
+};
+
+export const getSolutionsCurrentStatus = async (groupId: number) => {
+  const response = await kyJsonWithTokenInstance
+    .get<SolutionsCurrentStatusResponse[]>(
+      `api/groups/${groupId}/solutions/current-status`,
+    )
     .json();
 
   return response;

--- a/apps/client/src/app/api/type.ts
+++ b/apps/client/src/app/api/type.ts
@@ -58,3 +58,19 @@ export type MySolutionRequest = {
 export type MySolutionResponse = PaginationResponse & {
   content: SolutionContent[];
 };
+
+export type SolutionsCurrentStatus = {
+  problemId: number;
+  firstCorrectSolutionId?: number;
+  submissionCount: number;
+  firstCorrectDuration: string;
+  solved: boolean;
+};
+
+export type SolutionsCurrentStatusResponse = {
+  rank: number;
+  nickname: string;
+  totalSubmissionCount: number;
+  totalPassedTime: string;
+  problems: SolutionsCurrentStatus[];
+};

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/constant.tsx
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/constant.tsx
@@ -1,6 +1,6 @@
-import { SolutionsCurrentStatusResponse } from "@/app/api/type";
+import type { SolutionsCurrentStatusResponse } from "@/app/api/type";
 import { tdStyle } from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.css";
-import { TableDataType } from "@/shared/type/table";
+import type { TableDataType } from "@/shared/type/table";
 
 const SOLVED_STATUS_BASE_COLUMNS: TableDataType<SolutionsCurrentStatusResponse>[] =
   [

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/constant.tsx
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/constant.tsx
@@ -1,0 +1,35 @@
+import { SolutionsCurrentStatusResponse } from "@/app/api/type";
+import { tdStyle } from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.css";
+import { TableDataType } from "@/shared/type/table";
+
+const SOLVED_STATUS_BASE_COLUMNS: TableDataType<SolutionsCurrentStatusResponse>[] =
+  [
+    {
+      key: "rank",
+      Header: () => "랭킹",
+      Cell: (data) => data.rank,
+      width: 56,
+    },
+    {
+      key: "total",
+      Header: () => "총점",
+      Cell: (data) => (
+        <p className={tdStyle({ column: "totalScore" })}>
+          {data.totalSubmissionCount === 0 ? "-" : data.totalSubmissionCount}/
+          {data.totalPassedTime}
+        </p>
+      ),
+      width: 84,
+    },
+    {
+      key: "id",
+      Header: () => "아이디",
+      Cell: (data) => (
+        <p className={tdStyle({ column: "nickname" })}>{data.nickname}</p>
+      ),
+      width: 150,
+      align: "left",
+    },
+  ];
+
+export default SOLVED_STATUS_BASE_COLUMNS;

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.css.ts
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.css.ts
@@ -1,0 +1,80 @@
+import { theme } from "@/styles/themes.css";
+import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
+
+export const tableWrapper = style({
+  display: "flex",
+  width: "100%",
+});
+
+export const wrapper1Style = style({
+  width: "35%",
+  paddingBottom: "15px",
+});
+
+export const wrapper2Style = style({
+  width: "65%",
+});
+
+export const table1Style = style({
+  width: "100%",
+  height: "100%",
+  borderCollapse: "collapse",
+});
+
+export const table2Style = style({
+  width: "100%",
+  height: "100%",
+  borderCollapse: "collapse",
+  display: "block",
+  overflowX: "scroll",
+});
+
+export const theadStyle = style({
+  height: "4.1rem",
+});
+
+export const problemTdWrapper = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+});
+
+export const tdStyle = recipe({
+  base: {
+    color: theme.color.mg2,
+    ...theme.font.Caption3_M_12,
+  },
+  variants: {
+    column: {
+      rank: {},
+      nickname: {
+        color: theme.color.mg2,
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        maxWidth: "12.5rem",
+      },
+      totalScore: {
+        color: theme.color.yellow,
+      },
+      solvedProblem: {
+        width: "6rem",
+        height: "3rem",
+
+        color: theme.color.white,
+
+        background: theme.color.mg6,
+        borderRadius: "5px",
+        padding: "0.65rem 0.95rem",
+      },
+      unsolvedProblem: {
+        width: "6rem",
+        height: "3rem",
+        alignContent: "center",
+
+        ...theme.font.Caption3_M_12,
+      },
+    },
+  },
+});

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.tsx
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { DataTable } from "@/shared/component/Table";
+import {
+  table1Style,
+  table2Style,
+  tableWrapper,
+  theadStyle,
+  wrapper1Style,
+  wrapper2Style,
+} from "./index.css";
+import { useState } from "react";
+import { useSolvedStatusTable } from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/provider";
+import SOLVED_STATUS_BASE_COLUMNS from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/constant";
+
+const SolvedStatusTable = () => {
+  const { col, row } = useSolvedStatusTable();
+  const [hoveredRowIndex, setHoveredRowIndex] = useState<number | null>(null);
+
+  return (
+    <div className={tableWrapper}>
+      <DataTable
+        rows={row}
+        cols={SOLVED_STATUS_BASE_COLUMNS}
+        wrapperClassName={wrapper1Style}
+        theadClassName={theadStyle}
+        tableClassName={table1Style}
+        hoveredRowIndex={hoveredRowIndex}
+        onRowHoverChange={setHoveredRowIndex}
+      />
+      <DataTable
+        rows={row}
+        cols={col}
+        wrapperClassName={wrapper2Style}
+        theadClassName={theadStyle}
+        tableClassName={table2Style}
+        hoveredRowIndex={hoveredRowIndex}
+        onRowHoverChange={setHoveredRowIndex}
+      />
+    </div>
+  );
+};
+
+export default SolvedStatusTable;

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/provider.tsx
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/provider.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { SolutionsCurrentStatusResponse } from "@/app/api/type";
+import type { TableDataType } from "@/shared/type/table";
+import {
+  problemTdWrapper,
+  tdStyle,
+} from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.css";
+import { type ReactNode, createContext, useContext } from "react";
+
+type SolvedStatusTableContextValue = {
+  row: SolutionsCurrentStatusResponse[];
+  col: TableDataType<SolutionsCurrentStatusResponse>[];
+};
+
+const SolvedStatusTableContext =
+  createContext<SolvedStatusTableContextValue | null>(null);
+
+export const useSolvedStatusTable = () => {
+  const context = useContext(SolvedStatusTableContext);
+
+  if (!context) {
+    throw new Error(
+      "useSolvedStatusTable must be used within SolvedStatusTableProvider",
+    );
+  }
+
+  return context;
+};
+
+type SolvedStatusTableProviderProps = {
+  children: ReactNode;
+  value: SolutionsCurrentStatusResponse[];
+};
+
+export const SolvedStatusTableProvider = ({
+  children,
+  value,
+}: SolvedStatusTableProviderProps) => {
+  const problemColumns: TableDataType<SolutionsCurrentStatusResponse>[] =
+    value[0].problems.map((_, index) => ({
+      key: `problem${index + 1}`,
+      Header: () => `문제${index + 1}`,
+      Cell: (data) => (
+        <div className={problemTdWrapper}>
+          {data.problems[index].submissionCount === 0 ? (
+            <p className={tdStyle({ column: "unsolvedProblem" })}>0/--</p>
+          ) : (
+            <p className={tdStyle({ column: "solvedProblem" })}>
+              {data.problems[index].submissionCount}/
+              {data.problems[index].firstCorrectDuration}
+            </p>
+          )}
+        </div>
+      ),
+      width: 84,
+    }));
+
+  return (
+    <SolvedStatusTableContext.Provider
+      value={{ col: problemColumns, row: value }}
+    >
+      {children}
+    </SolvedStatusTableContext.Provider>
+  );
+};

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/index.tsx
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/index.tsx
@@ -1,0 +1,31 @@
+import { SolvedStatusTableProvider } from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/provider";
+import { SolutionsCurrentStatusResponse } from "@/app/api/type";
+import { titleStyle } from "@/app/group/[groupId]/page.css";
+import SolvedStatusTable from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable";
+import Empty from "@/shared/component/Empty";
+
+type SolvedStatusSectionProps = {
+  solutionsCurrentStatusInfo: SolutionsCurrentStatusResponse[];
+};
+
+const SolvedStatusSection = ({
+  solutionsCurrentStatusInfo,
+}: SolvedStatusSectionProps) => {
+  const hasInProgressProblems =
+    solutionsCurrentStatusInfo[0].problems.length > 0;
+
+  return (
+    <section>
+      <h2 className={titleStyle}>진행 중인 풀이 현황</h2>
+      {hasInProgressProblems ? (
+        <SolvedStatusTableProvider value={solutionsCurrentStatusInfo}>
+          <SolvedStatusTable />
+        </SolvedStatusTableProvider>
+      ) : (
+        <Empty guideText="진행중인 문제가 없습니다." />
+      )}
+    </section>
+  );
+};
+
+export default SolvedStatusSection;

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/index.tsx
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/index.tsx
@@ -1,5 +1,5 @@
 import { SolvedStatusTableProvider } from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/provider";
-import { SolutionsCurrentStatusResponse } from "@/app/api/type";
+import type { SolutionsCurrentStatusResponse } from "@/app/api/type";
 import { titleStyle } from "@/app/group/[groupId]/page.css";
 import SolvedStatusTable from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable";
 import Empty from "@/shared/component/Empty";

--- a/apps/client/src/app/group/[groupId]/notice/layout.tsx
+++ b/apps/client/src/app/group/[groupId]/notice/layout.tsx
@@ -1,14 +1,15 @@
 import { getGroupInfo, getGroupMemberList } from "@/app/api/groups";
 import { getDeadlineReachedProblems } from "@/app/api/groups";
 import { getTopRanking } from "@/app/api/groups/ranking";
-import { listSectionStyle, titleStyle } from "@/app/group/[groupId]/page.css";
+import { listSectionStyle } from "@/app/group/[groupId]/page.css";
+import { getSolutionsCurrentStatus } from "@/app/api/solutions";
 import Sidebar from "@/common/component/Sidebar";
-import ProblemList from "@/shared/component/ProblemList";
 import { sidebarWrapper } from "@/styles/shared.css";
 import type { ReactNode } from "react";
 import GroupSidebar from "../components/GroupSidebar";
 import NoticeBanner from "../components/NoticeBanner";
 import Ranking from "../components/Ranking";
+import SolvedStatusSection from "@/app/group/[groupId]/components/SolvedStatusSection";
 
 const GroupDashboardLayout = async ({
   params: { groupId },
@@ -18,14 +19,16 @@ const GroupDashboardLayout = async ({
   const rankingData = getTopRanking(+groupId);
   const memberData = getGroupMemberList(+groupId);
   const deadlineReachedData = getDeadlineReachedProblems(+groupId);
+  const solutionsCurrentStatusData = getSolutionsCurrentStatus(+groupId);
 
-  const [groupInfo, rankingInfo, memberInfo, deadlineReachedInfo] =
+  const [groupInfo, rankingInfo, memberInfo, solutionsCurrentStatusInfo] =
     await Promise.all([
       groupInfoData,
       rankingData,
       memberData,
-      deadlineReachedData,
+      solutionsCurrentStatusData,
     ]);
+
 
   return (
     <main className={sidebarWrapper}>
@@ -35,15 +38,9 @@ const GroupDashboardLayout = async ({
       <div className={listSectionStyle}>
         <NoticeBanner />
         <Ranking rankingData={rankingInfo} />
-        <h2 className={titleStyle}>풀어야 할 문제</h2>
-        <section>
-          <ProblemList.Header />
-          <ProblemList>
-            {deadlineReachedInfo.map((item) => (
-              <ProblemList.Item key={item.problemId} {...item} />
-            ))}
-          </ProblemList>
-        </section>
+        <SolvedStatusSection
+          solutionsCurrentStatusInfo={solutionsCurrentStatusInfo}
+        />
       </div>
       {children}
     </main>

--- a/apps/client/src/app/group/[groupId]/notice/layout.tsx
+++ b/apps/client/src/app/group/[groupId]/notice/layout.tsx
@@ -1,5 +1,4 @@
 import { getGroupInfo, getGroupMemberList } from "@/app/api/groups";
-import { getDeadlineReachedProblems } from "@/app/api/groups";
 import { getTopRanking } from "@/app/api/groups/ranking";
 import { listSectionStyle } from "@/app/group/[groupId]/page.css";
 import { getSolutionsCurrentStatus } from "@/app/api/solutions";
@@ -18,7 +17,6 @@ const GroupDashboardLayout = async ({
   const groupInfoData = getGroupInfo(+groupId);
   const rankingData = getTopRanking(+groupId);
   const memberData = getGroupMemberList(+groupId);
-  const deadlineReachedData = getDeadlineReachedProblems(+groupId);
   const solutionsCurrentStatusData = getSolutionsCurrentStatus(+groupId);
 
   const [groupInfo, rankingInfo, memberInfo, solutionsCurrentStatusInfo] =
@@ -28,7 +26,6 @@ const GroupDashboardLayout = async ({
       memberData,
       solutionsCurrentStatusData,
     ]);
-
 
   return (
     <main className={sidebarWrapper}>

--- a/apps/client/src/app/group/[groupId]/page.tsx
+++ b/apps/client/src/app/group/[groupId]/page.tsx
@@ -1,9 +1,5 @@
 import ExtensionAlertModalController from "@/app/[user]/components/ExtensionAlertModal";
-import {
-  getDeadlineReachedProblems,
-  getGroupInfo,
-  getGroupMemberList,
-} from "@/app/api/groups";
+import { getGroupInfo, getGroupMemberList } from "@/app/api/groups";
 import { getAllRanking, getTopRanking } from "@/app/api/groups/ranking";
 import { getSolutionsCurrentStatus } from "@/app/api/solutions";
 import GroupSidebar from "@/app/group/[groupId]/components/GroupSidebar";
@@ -22,7 +18,6 @@ const GroupDashboardPage = async ({
   const groupInfoData = getGroupInfo(+groupId);
   const rankingData = getTopRanking(+groupId);
   const memberData = getGroupMemberList(+groupId);
-  const deadlineReachedData = getDeadlineReachedProblems(+groupId);
   const solutionsCurrentStatusData = getSolutionsCurrentStatus(+groupId);
 
   const [groupInfo, rankingInfo, memberInfo, solutionsCurrentStatusInfo] =

--- a/apps/client/src/app/group/[groupId]/page.tsx
+++ b/apps/client/src/app/group/[groupId]/page.tsx
@@ -5,12 +5,13 @@ import {
   getGroupMemberList,
 } from "@/app/api/groups";
 import { getAllRanking, getTopRanking } from "@/app/api/groups/ranking";
+import { getSolutionsCurrentStatus } from "@/app/api/solutions";
 import GroupSidebar from "@/app/group/[groupId]/components/GroupSidebar";
 import NoticeBanner from "@/app/group/[groupId]/components/NoticeBanner";
 import Ranking from "@/app/group/[groupId]/components/Ranking";
-import { listSectionStyle, titleStyle } from "@/app/group/[groupId]/page.css";
+import SolvedStatusSection from "@/app/group/[groupId]/components/SolvedStatusSection";
+import { listSectionStyle } from "@/app/group/[groupId]/page.css";
 import Sidebar from "@/common/component/Sidebar";
-import ProblemList from "@/shared/component/ProblemList";
 import { prefetchQuery } from "@/shared/util/prefetch";
 import { sidebarWrapper } from "@/styles/shared.css";
 import { HydrationBoundary } from "@tanstack/react-query";
@@ -22,13 +23,14 @@ const GroupDashboardPage = async ({
   const rankingData = getTopRanking(+groupId);
   const memberData = getGroupMemberList(+groupId);
   const deadlineReachedData = getDeadlineReachedProblems(+groupId);
+  const solutionsCurrentStatusData = getSolutionsCurrentStatus(+groupId);
 
-  const [groupInfo, rankingInfo, memberInfo, deadlineReachedInfo] =
+  const [groupInfo, rankingInfo, memberInfo, solutionsCurrentStatusInfo] =
     await Promise.all([
       groupInfoData,
       rankingData,
       memberData,
-      deadlineReachedData,
+      solutionsCurrentStatusData,
     ]);
 
   const firstPage = 1;
@@ -47,15 +49,12 @@ const GroupDashboardPage = async ({
         <HydrationBoundary state={dehydratedState}>
           <Ranking rankingData={rankingInfo} />
         </HydrationBoundary>
-        <h2 className={titleStyle}>풀어야 할 문제</h2>
-        <section>
-          <ProblemList.Header />
-          <ProblemList>
-            {deadlineReachedInfo.map((item) => (
-              <ProblemList.Item key={item.problemId} {...item} />
-            ))}
-          </ProblemList>
-        </section>
+        <SolvedStatusSection
+          solutionsCurrentStatusInfo={[
+            ...solutionsCurrentStatusInfo,
+            ...solutionsCurrentStatusInfo,
+          ]}
+        />
       </div>
       <ExtensionAlertModalController domain="group" />
     </main>

--- a/apps/client/src/shared/component/Table/TableElements/Body.tsx
+++ b/apps/client/src/shared/component/Table/TableElements/Body.tsx
@@ -2,21 +2,32 @@ import type { TableDataType } from "@/shared/type/table";
 import clsx from "clsx";
 import type { Attributes } from "react";
 import TableCell from "./TableCell";
-import { tableCellTextStyle, tableRowStyle } from "./index.css";
+import { tableCellTextStyle, tableRowHoveredStyle, tableRowStyle } from "./index.css";
 
 type BodyProps<T> = {
   rows: T[];
   cols: TableDataType<T>[];
   trClassName?: string;
   tdClassName?: string;
+  hoveredRowIndex?: number | null;
+  onRowHoverChange?: (rowIndex: number | null) => void;
 };
 
-const Body = <T,>({ rows, cols, trClassName, tdClassName }: BodyProps<T>) => {
+const Body = <T,>({ rows, cols, trClassName, tdClassName, hoveredRowIndex, onRowHoverChange }: BodyProps<T>) => {
   return (
     <tbody>
       {rows.map((row, idx) => (
         // TODO: api 연결 후, raw data에 고유 id값 추가 등의 방안으로 key 교체하기
-        <tr key={idx} className={clsx(trClassName, tableRowStyle)}>
+        <tr
+        key={idx}
+        className={clsx(
+          trClassName,
+          tableRowStyle,
+          hoveredRowIndex === idx && tableRowHoveredStyle,
+        )}
+        onMouseEnter={() => onRowHoverChange?.(idx)}
+        onMouseLeave={() => onRowHoverChange?.(null)}
+      >
           {cols.map(({ key, align, Cell }) => (
             <TableCell
               key={key?.toString()}

--- a/apps/client/src/shared/component/Table/TableElements/Body.tsx
+++ b/apps/client/src/shared/component/Table/TableElements/Body.tsx
@@ -2,7 +2,11 @@ import type { TableDataType } from "@/shared/type/table";
 import clsx from "clsx";
 import type { Attributes } from "react";
 import TableCell from "./TableCell";
-import { tableCellTextStyle, tableRowHoveredStyle, tableRowStyle } from "./index.css";
+import {
+  tableCellTextStyle,
+  tableRowHoveredStyle,
+  tableRowStyle,
+} from "./index.css";
 
 type BodyProps<T> = {
   rows: T[];
@@ -13,21 +17,28 @@ type BodyProps<T> = {
   onRowHoverChange?: (rowIndex: number | null) => void;
 };
 
-const Body = <T,>({ rows, cols, trClassName, tdClassName, hoveredRowIndex, onRowHoverChange }: BodyProps<T>) => {
+const Body = <T,>({
+  rows,
+  cols,
+  trClassName,
+  tdClassName,
+  hoveredRowIndex,
+  onRowHoverChange,
+}: BodyProps<T>) => {
   return (
     <tbody>
       {rows.map((row, idx) => (
         // TODO: api 연결 후, raw data에 고유 id값 추가 등의 방안으로 key 교체하기
         <tr
-        key={idx}
-        className={clsx(
-          trClassName,
-          tableRowStyle,
-          hoveredRowIndex === idx && tableRowHoveredStyle,
-        )}
-        onMouseEnter={() => onRowHoverChange?.(idx)}
-        onMouseLeave={() => onRowHoverChange?.(null)}
-      >
+          key={idx}
+          className={clsx(
+            trClassName,
+            tableRowStyle,
+            hoveredRowIndex === idx && tableRowHoveredStyle,
+          )}
+          onMouseEnter={() => onRowHoverChange?.(idx)}
+          onMouseLeave={() => onRowHoverChange?.(null)}
+        >
           {cols.map(({ key, align, Cell }) => (
             <TableCell
               key={key?.toString()}

--- a/apps/client/src/shared/component/Table/TableElements/TableHead.tsx
+++ b/apps/client/src/shared/component/Table/TableElements/TableHead.tsx
@@ -11,7 +11,7 @@ const TableHead = ({ className, align, width, ...props }: TableHeadProps) => {
   return (
     <th
       className={clsx(tableHeadStyle({ align }), className)}
-      style={{ width: `${width}px` }}
+      style={{ minWidth: `${width}px`, width: `${width}px` }}
       {...props}
     />
   );

--- a/apps/client/src/shared/component/Table/TableElements/index.css.ts
+++ b/apps/client/src/shared/component/Table/TableElements/index.css.ts
@@ -91,6 +91,10 @@ export const tableCellStyle = recipe({
   },
 });
 
+export const tableRowHoveredStyle = style({
+  backgroundColor: theme.color.mg5,
+});
+
 export const tableCellTextStyle = style({
   ...theme.font.Caption3_M_12,
   color: theme.color.white,

--- a/apps/client/src/shared/component/Table/index.tsx
+++ b/apps/client/src/shared/component/Table/index.tsx
@@ -25,6 +25,10 @@ type DataTableProps<T> = {
   /** tbody의 tr만 적용. thead의 tr은 적용되지 않음 */
   trClassName?: string;
   tdClassName?: string;
+  /** 행 호버 동기화 인덱스 */
+  hoveredRowIndex?: number | null;
+  /** 행 호버 변경 핸들러 */
+  onRowHoverChange?: (rowIndex: number | null) => void;
 };
 
 export const DataTable = <T,>({
@@ -38,6 +42,8 @@ export const DataTable = <T,>({
   thClassName,
   trClassName,
   tdClassName,
+  hoveredRowIndex,
+  onRowHoverChange,
 }: DataTableProps<T>) => {
   return (
     <div className={clsx(wrapperStyle, wrapperClassName)}>
@@ -57,6 +63,8 @@ export const DataTable = <T,>({
           cols={cols}
           trClassName={trClassName}
           tdClassName={tdClassName}
+          hoveredRowIndex={hoveredRowIndex}
+          onRowHoverChange={onRowHoverChange}
         />
       </table>
     </div>


### PR DESCRIPTION
## ✅ Done Task
  - [x] 풀이 현황 테이블 구현
  - [x] 행 호버 동기화

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

- Table을 두개로 나눈 이유
  - 오른쪽 문제 테이블에만 가로 스크롤이 적용되어야했기에 Table을 두개로 나누었습니다
  - 이에 따라 행 호버 동기화 효과가 필요해서 `Table` 컴포넌트에 `hoveredRowIndex` `onRowHoverChange`를 추가시켰습니다
  - 테이블 컴포넌트가 계속 비대해져서 속상하지만 .. 테이블 컴포넌트는 나중에 리팩토링 하면 좋을 것 같습니다

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

<img width="588" height="175" alt="image" src="https://github.com/user-attachments/assets/c334f8ee-7974-48d3-9990-7764cd11a364" />

분명 `scrollTheme` 이 설정되어있는데도 스크롤에 theme 적용이 안 되는 것 같아요
이 부분 마이너해서 티켓으로 만들어두었습니다! ([#](https://linear.app/algo-hub/issue/FE-110/scroll-theme-적용))

+) 너무 오래전부터 구현해오던 거라 rebase가 어려워 백머지했어요 .. 커밋기록 난잡한거 양해부탁드립니다 TT `SolvedStatusSection` 만 봐주시면 돼요! ([#](https://github.com/GAMZA-BAT/algohub-client/pull/446/files#diff-3c6d7f60a73ffc43bdf5c90d54626431d798b2153a8b35b386c65aa1498a28d7))

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/5a1c107e-b858-4684-a0d3-92d6810821c9" />
