### PR TITLE
[ Fix ] 닉네임 변경 후 url 업데이트

### DIFF
--- a/apps/client/src/app/[user]/setting/components/MyProfile/EditForm/index.tsx
+++ b/apps/client/src/app/[user]/setting/components/MyProfile/EditForm/index.tsx
@@ -14,12 +14,14 @@ import SubmitButton from "@/shared/component/SubmitButton";
 import { HTTP_ERROR_STATUS } from "@/shared/constant/api";
 import { handleOnChangeMode } from "@/shared/util/form";
 import { getSession, useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import type { z } from "zod";
 import { contentStyle, formStyle, labelStyle } from "./index.css";
 import type { baseEditSchema } from "./schema";
 import useEditForm from "./useEditForm";
 
 const EditForm = () => {
+  const router = useRouter();
   const { data, update } = useSession();
   const {
     form,
@@ -34,6 +36,9 @@ const EditForm = () => {
   const handleSubmit = async (values: z.infer<typeof baseEditSchema>) => {
     const response = await _handleSubmit(values);
     if (response.status === 200) {
+      const originalNickname = data?.user?.nickname;
+      const { nickname: newNickname } = values;
+
       await update(await getSession());
 
       form.reset(values, {
@@ -41,6 +46,9 @@ const EditForm = () => {
         keepDirty: false, // dirty 상태 초기화
       });
 
+      if (originalNickname && newNickname && originalNickname !== newNickname) {
+        router.replace(`/${newNickname}/setting`);
+      }
       showToast("정상적으로 수정되었어요.", "success");
     } else if (response.status === HTTP_ERROR_STATUS.INTERNAL_SERVER_ERROR)
       showToast("정상적으로 수정되지 않았어요.", "error");


### PR DESCRIPTION
## ✅ Done Task
  - [x] 닉네임 변경 시 url 업데이트

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
원래 닉네임과 바꾼 닉네임이 존재하고, 둘이 다르다면 url을 업데이트 하는 로직이 추가되었습니다.
이전에 `EditForm`과 `useEditForm - handleSubmit`의 역할을 잘 분리해서 개발한 덕에 수정이 쉬웠네요.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->