### PR TITLE
[ Fix ] 테이블 외부 요소가 잘리던 원인 제거

### DIFF
--- a/apps/client/src/shared/component/Table/TableElements/index.css.ts
+++ b/apps/client/src/shared/component/Table/TableElements/index.css.ts
@@ -3,7 +3,6 @@ import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
 export const wrapperStyle = style({
-  position: "relative",
   display: "flex",
   alignItems: "flex-start",
   justifyContent: "center",


### PR DESCRIPTION
## ✅ Done Task
  - [x] 스타일 수정

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
단순 수정입니다.
## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
현재 테이블 wrapper(div)의 css 속성이 position: relative; overflow: auto로 되어 있어서 테이블 영역을 벗어나는 요소가 있으면 스크롤이 생겨야 했습니다. 근데 이전 개발 요구사항에 따라 추가적으로 스크롤 바가 나타나지 않게 해놔서 생긴 문제였습니다.

overflow를 visible로 하거나 position을 없애면 되는데, 확인 결과 position이 없어져도 변화가 없는걸로 확인되어 position을 없앴습니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
![SmartSelect_20250918_192915_Chrome](https://github.com/user-attachments/assets/8ac3aef4-025f-4009-b373-d039a120159e)
