### PR TITLE
[ Feat ] 추천 스터디 모달 및 api (3/4) - 가입 요청자 리스트 섹션

### DIFF
--- a/apps/client/src/app/[user]/components/JoinRequestAlertModal.tsx
+++ b/apps/client/src/app/[user]/components/JoinRequestAlertModal.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { MOCK_JOIN_REQUESTS } from "@/app/group/[groupId]/setting/components/JoinRequestList";
+import { modalStyle } from "@/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.css";
+import GroupActionModal from "@/shared/component/GroupActionModal";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type JoinRequestAlertModalControllerProps = {
+  groupName: string;
+  groupId: string;
+};
+
+export const JoinRequestAlertModalController = ({
+  groupName,
+  groupId,
+}: JoinRequestAlertModalControllerProps) => {
+  const router = useRouter();
+  // 요청자 배열
+  const { name, avatarUrl } = MOCK_JOIN_REQUESTS[0];
+
+  // TODO: useSuspenseQuery로 isOpen 대체하기
+  // + stale time 설정해서 refetch하고, 갱신됐으면 세션 스토리지 초기화해서 재표시
+  const [isOpen, setIsOpen] = useState(false);
+
+  const sessionStorageKey = `joinRequestAlertShown-${groupId}`;
+
+  useEffect(() => {
+    const hasBeenShown = sessionStorage.getItem(sessionStorageKey);
+    if (!hasBeenShown) {
+      setIsOpen(true);
+    }
+  }, [groupId, sessionStorageKey]);
+
+  const handleApprove = () => {
+    router.push(`/group/${groupId}/setting`);
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    sessionStorage.setItem(sessionStorageKey, "true");
+  };
+
+  return (
+    <GroupActionModal
+      className={modalStyle}
+      isOpen={isOpen}
+      onClose={handleClose}
+    >
+      <GroupActionModal.Applicant nickname={name} profileImage={avatarUrl} />
+      <GroupActionModal.Prompt
+        variant="applicant"
+        applicantName={name}
+        groupName={groupName}
+        count={MOCK_JOIN_REQUESTS.length}
+      />
+      <GroupActionModal.Actions
+        onConfirm={handleApprove}
+        onReject={handleClose}
+        confirmText="승인하러가기"
+        rejectText="닫기"
+      />
+    </GroupActionModal>
+  );
+};

--- a/apps/client/src/app/group/[groupId]/page.tsx
+++ b/apps/client/src/app/group/[groupId]/page.tsx
@@ -1,4 +1,5 @@
 import ExtensionAlertModalController from "@/app/[user]/components/ExtensionAlertModal";
+import { JoinRequestAlertModalController } from "@/app/[user]/components/JoinRequestAlertModal";
 import { getGroupInfo, getGroupMemberList } from "@/app/api/groups";
 import { getAllRanking, getTopRanking } from "@/app/api/groups/ranking";
 import { getSolutionsCurrentStatus } from "@/app/api/solutions";
@@ -49,6 +50,10 @@ const GroupDashboardPage = async ({
         />
       </div>
       <ExtensionAlertModalController domain="group" />
+      <JoinRequestAlertModalController
+        groupName={groupInfo.name}
+        groupId={groupId}
+      />
     </main>
   );
 };

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.css.ts
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.css.ts
@@ -1,0 +1,88 @@
+import { theme } from "@/styles/themes.css";
+import { style } from "@vanilla-extract/css";
+
+export const cardStyle = style({
+  position: "relative",
+
+  padding: "1.2rem 2rem",
+  width: "100%",
+  height: "6.4rem",
+
+  border: `1px solid ${theme.color.mg5}`,
+  borderRadius: "1rem",
+
+  backgroundColor: theme.color.mg6,
+
+  selectors: {
+    "&:hover": {
+      boxShadow: "0 4px 16px 0 rgba(0,0,0,0.08)",
+      borderColor: theme.color.mg3,
+    },
+  },
+});
+
+export const modalTriggerButtonStyle = style({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100%",
+  height: "100%",
+  zIndex: 1,
+  cursor: "pointer",
+
+  border: "none",
+  background: "none",
+  padding: "inherit",
+  color: "inherit",
+  textAlign: "left",
+
+  display: "flex",
+  alignItems: "center",
+  gap: "0.8rem",
+
+  selectors: {
+    "&:focus-visible": {
+      outline: `2px solid ${theme.color.blue}`,
+      outlineOffset: "-2px",
+    },
+  },
+});
+
+export const descriptionWrapper = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "0.8rem",
+});
+
+export const iconStyle = style({
+  width: "3.2rem",
+  height: "3.2rem",
+});
+
+export const nameStyle = style({
+  ...theme.font.Body3_SB_14,
+  color: theme.color.white,
+});
+
+export const textStyle = style({
+  ...theme.font.Body3_SB_14,
+  color: theme.color.mg3,
+});
+
+export const actionWrapperStyle = style({
+  position: "absolute",
+
+  right: "2rem",
+  top: "50%",
+  transform: "translateY(-50%)",
+  zIndex: 2,
+
+  display: "flex",
+  flexDirection: "row",
+  gap: "0.8rem",
+});
+
+export const actionButtonStyle = style({
+  width: "9.6rem",
+  height: "4rem",
+});

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.css.ts
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.css.ts
@@ -12,13 +12,6 @@ export const cardStyle = style({
   borderRadius: "1rem",
 
   backgroundColor: theme.color.mg6,
-
-  selectors: {
-    "&:hover": {
-      boxShadow: "0 4px 16px 0 rgba(0,0,0,0.08)",
-      borderColor: theme.color.mg3,
-    },
-  },
 });
 
 export const modalTriggerButtonStyle = style({

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.css.ts
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.css.ts
@@ -86,3 +86,7 @@ export const actionButtonStyle = style({
   width: "9.6rem",
   height: "4rem",
 });
+
+export const modalStyle = style({
+  height: "fit-content",
+});

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.tsx
@@ -2,6 +2,8 @@
 
 import Avatar from "@/common/component/Avatar";
 import Button from "@/common/component/Button";
+import { useBooleanState } from "@/common/hook/useBooleanState";
+import GroupActionModal from "@/shared/component/GroupActionModal";
 import { useId } from "react";
 import {
   actionButtonStyle,
@@ -9,6 +11,7 @@ import {
   cardStyle,
   descriptionWrapper,
   iconStyle,
+  modalStyle,
   modalTriggerButtonStyle,
   nameStyle,
   textStyle,
@@ -16,27 +19,32 @@ import {
 
 type ApprovalCardProps = {
   name: string;
+  groupName: string;
   avatarUrl: string;
 };
 
-export const ApprovalCard = ({ name, avatarUrl }: ApprovalCardProps) => {
+export const ApprovalCard = ({
+  name,
+  groupName,
+  avatarUrl,
+}: ApprovalCardProps) => {
+  const { isOpen, open, close } = useBooleanState();
   const nameId = useId();
 
   const handleApprove = (e: React.MouseEvent) => {
     e.stopPropagation();
     console.log(`Approving ${name}`);
-    // TODO: Implement approve logic
+    close();
   };
 
   const handleReject = (e: React.MouseEvent) => {
     e.stopPropagation();
     console.log(`Rejecting ${name}`);
-    // TODO: Implement reject logic
+    close();
   };
 
   const handleOpenModal = () => {
-    console.log(`${name}님의 가입 요청 상세 모달 열기`);
-    // TODO: 모달을 여는 로직 구현
+    open();
   };
 
   return (
@@ -53,15 +61,12 @@ export const ApprovalCard = ({ name, avatarUrl }: ApprovalCardProps) => {
             src={avatarUrl}
             alt={`${name}의 프로필 사진`}
           />
-          <p className={textStyle}>
-            <span id={nameId} className={nameStyle}>
-              {name}
-            </span>
+          <p id={nameId} className={textStyle}>
+            <span className={nameStyle}>{name}</span>
             님의 스터디 가입 요청
           </p>
         </div>
       </button>
-
       <div className={actionWrapperStyle}>
         <Button
           size="small"
@@ -82,6 +87,20 @@ export const ApprovalCard = ({ name, avatarUrl }: ApprovalCardProps) => {
           거절하기
         </Button>
       </div>
+      <GroupActionModal className={modalStyle} isOpen={isOpen} onClose={close}>
+        <GroupActionModal.Applicant nickname={name} profileImage={avatarUrl} />
+        <GroupActionModal.Prompt
+          variant="applicant"
+          applicantName={name}
+          groupName={groupName}
+        />
+        <GroupActionModal.Actions
+          onConfirm={handleApprove}
+          onReject={handleReject}
+          confirmText="승인하기"
+          rejectText="거절하기"
+        />
+      </GroupActionModal>
     </article>
   );
 };

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.tsx
@@ -2,8 +2,6 @@
 
 import Avatar from "@/common/component/Avatar";
 import Button from "@/common/component/Button";
-import { useBooleanState } from "@/common/hook/useBooleanState";
-import GroupActionModal from "@/shared/component/GroupActionModal";
 import { useId } from "react";
 import {
   actionButtonStyle,
@@ -11,8 +9,6 @@ import {
   cardStyle,
   descriptionWrapper,
   iconStyle,
-  modalStyle,
-  modalTriggerButtonStyle,
   nameStyle,
   textStyle,
 } from "./index.css";
@@ -23,50 +19,33 @@ type ApprovalCardProps = {
   avatarUrl: string;
 };
 
-export const ApprovalCard = ({
-  name,
-  groupName,
-  avatarUrl,
-}: ApprovalCardProps) => {
-  const { isOpen, open, close } = useBooleanState();
+export const ApprovalCard = ({ name, avatarUrl }: ApprovalCardProps) => {
   const nameId = useId();
 
   const handleApprove = (e: React.MouseEvent) => {
     e.stopPropagation();
     console.log(`Approving ${name}`);
-    close();
   };
 
   const handleReject = (e: React.MouseEvent) => {
     e.stopPropagation();
     console.log(`Rejecting ${name}`);
-    close();
-  };
-
-  const handleOpenModal = () => {
-    open();
   };
 
   return (
     <article className={cardStyle} aria-labelledby={nameId}>
-      <button
-        type="button"
-        className={modalTriggerButtonStyle}
-        onClick={handleOpenModal}
-        aria-label={`${name}님의 스터디 가입 요청 상세 보기`}
-      >
-        <div className={descriptionWrapper}>
-          <Avatar
-            className={iconStyle}
-            src={avatarUrl}
-            alt={`${name}의 프로필 사진`}
-          />
-          <p id={nameId} className={textStyle}>
-            <span className={nameStyle}>{name}</span>
-            님의 스터디 가입 요청
-          </p>
-        </div>
-      </button>
+      <div className={descriptionWrapper}>
+        <Avatar
+          className={iconStyle}
+          src={avatarUrl}
+          alt={`${name}의 프로필 사진`}
+        />
+        <p id={nameId} className={textStyle}>
+          <span className={nameStyle}>{name}</span>
+          님의 스터디 가입 요청
+        </p>
+      </div>
+
       <div className={actionWrapperStyle}>
         <Button
           size="small"
@@ -87,20 +66,6 @@ export const ApprovalCard = ({
           거절하기
         </Button>
       </div>
-      <GroupActionModal className={modalStyle} isOpen={isOpen} onClose={close}>
-        <GroupActionModal.Applicant nickname={name} profileImage={avatarUrl} />
-        <GroupActionModal.Prompt
-          variant="applicant"
-          applicantName={name}
-          groupName={groupName}
-        />
-        <GroupActionModal.Actions
-          onConfirm={handleApprove}
-          onReject={handleReject}
-          confirmText="승인하기"
-          rejectText="거절하기"
-        />
-      </GroupActionModal>
     </article>
   );
 };

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/ApprovalCard/index.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Avatar from "@/common/component/Avatar";
+import Button from "@/common/component/Button";
+import { useId } from "react";
+import {
+  actionButtonStyle,
+  actionWrapperStyle,
+  cardStyle,
+  descriptionWrapper,
+  iconStyle,
+  modalTriggerButtonStyle,
+  nameStyle,
+  textStyle,
+} from "./index.css";
+
+type ApprovalCardProps = {
+  name: string;
+  avatarUrl: string;
+};
+
+export const ApprovalCard = ({ name, avatarUrl }: ApprovalCardProps) => {
+  const nameId = useId();
+
+  const handleApprove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    console.log(`Approving ${name}`);
+    // TODO: Implement approve logic
+  };
+
+  const handleReject = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    console.log(`Rejecting ${name}`);
+    // TODO: Implement reject logic
+  };
+
+  const handleOpenModal = () => {
+    console.log(`${name}님의 가입 요청 상세 모달 열기`);
+    // TODO: 모달을 여는 로직 구현
+  };
+
+  return (
+    <article className={cardStyle} aria-labelledby={nameId}>
+      <button
+        type="button"
+        className={modalTriggerButtonStyle}
+        onClick={handleOpenModal}
+        aria-label={`${name}님의 스터디 가입 요청 상세 보기`}
+      >
+        <div className={descriptionWrapper}>
+          <Avatar
+            className={iconStyle}
+            src={avatarUrl}
+            alt={`${name}의 프로필 사진`}
+          />
+          <p className={textStyle}>
+            <span id={nameId} className={nameStyle}>
+              {name}
+            </span>
+            님의 스터디 가입 요청
+          </p>
+        </div>
+      </button>
+
+      <div className={actionWrapperStyle}>
+        <Button
+          size="small"
+          color="purple"
+          isActive
+          className={actionButtonStyle}
+          onClick={handleApprove}
+        >
+          승인하기
+        </Button>
+        <Button
+          size="small"
+          color="lg"
+          isActive
+          className={actionButtonStyle}
+          onClick={handleReject}
+        >
+          거절하기
+        </Button>
+      </div>
+    </article>
+  );
+};

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.css.ts
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.css.ts
@@ -1,0 +1,55 @@
+import { theme } from "@/styles/themes.css";
+import { style } from "@vanilla-extract/css";
+
+export const joinRequestSectionWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.6rem",
+});
+
+export const joinRequestHeaderWrapper = style({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+});
+
+export const joinRequestHeadStyle = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+});
+
+export const joinRequestStyle = style({
+  color: theme.color.lg2,
+  ...theme.font.Title1_SB_16,
+});
+
+export const countStyle = style({
+  color: theme.color.purple,
+  ...theme.font.Title1_SB_16,
+});
+
+export const buttonStyle = style({
+  width: "3.2rem",
+  height: "3.2rem",
+  borderRadius: "50%",
+  backgroundColor: "transparent",
+  transition: "background-color 0.2s ease-in-out",
+
+  selectors: {
+    "&:hover": {
+      backgroundColor: theme.color.mg5,
+    },
+    "&:disabled": {
+      backgroundColor: "unset!important",
+      cursor: "unset",
+      opacity: 0.5,
+    },
+  },
+});
+
+export const cardListWrapperStyle = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.6rem",
+});

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
@@ -2,7 +2,7 @@
 
 import { IcnBtnArrowLeft, IcnBtnArrowRight } from "@/asset/svg";
 import { AnimatePresence, motion } from "framer-motion";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ApprovalCard } from "./ApprovalCard";
 import {
   buttonStyle,
@@ -26,11 +26,17 @@ const JoinRequestList = ({ groupName }: { groupName: string }) => {
   const [currentPage, setCurrentPage] = useState(0);
   const [isDownDirection, setIsDownDirection] = useState(true);
 
-  const totalPages = Math.ceil(MOCK_JOIN_REQUESTS.length / ITEMS_PER_PAGE);
-  if (!totalPages) return null;
+  const totalPages = useMemo(
+    () => Math.ceil(MOCK_JOIN_REQUESTS.length / ITEMS_PER_PAGE),
+    [MOCK_JOIN_REQUESTS.length],
+  );
   const startIndex = currentPage * ITEMS_PER_PAGE;
-  const endIndex = startIndex + ITEMS_PER_PAGE;
-  const currentRequests = MOCK_JOIN_REQUESTS.slice(startIndex, endIndex);
+  const currentRequests = MOCK_JOIN_REQUESTS.slice(
+    startIndex,
+    startIndex + ITEMS_PER_PAGE,
+  );
+
+  if (!totalPages) return null;
 
   const handlePrev = () => {
     setIsDownDirection(false);
@@ -45,11 +51,11 @@ const JoinRequestList = ({ groupName }: { groupName: string }) => {
   return (
     <section
       className={joinRequestSectionWrapper}
-      aria-labelledby="join-requst-title"
+      aria-labelledby="join-request-title"
     >
       <div className={joinRequestHeaderWrapper}>
         <div className={joinRequestHeadStyle}>
-          <h2 id="join-requst-title" className={joinRequestStyle}>
+          <h2 id="join-request-title" className={joinRequestStyle}>
             가입 요청
           </h2>
           <span className={countStyle}>{MOCK_JOIN_REQUESTS.length}</span>

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
@@ -22,7 +22,7 @@ const MOCK_JOIN_REQUESTS = Array.from({ length: 8 }, (_, i) => ({
 
 const ITEMS_PER_PAGE = 3;
 
-const JoinRequestList = () => {
+const JoinRequestList = ({ groupName }: { groupName: string }) => {
   const [currentPage, setCurrentPage] = useState(0);
 
   const totalPages = Math.ceil(MOCK_JOIN_REQUESTS.length / ITEMS_PER_PAGE);
@@ -85,8 +85,8 @@ const JoinRequestList = () => {
           {currentRequests.map((request) => (
             <li key={request.id}>
               <ApprovalCard
-                key={request.id}
                 name={request.name}
+                groupName={groupName}
                 avatarUrl={request.avatarUrl}
               />
             </li>

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { IcnBtnArrowLeft, IcnBtnArrowRight } from "@/asset/svg";
+import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
+import { ApprovalCard } from "./ApprovalCard";
+import {
+  buttonStyle,
+  cardListWrapperStyle,
+  countStyle,
+  joinRequestHeadStyle,
+  joinRequestHeaderWrapper,
+  joinRequestSectionWrapper,
+  joinRequestStyle,
+} from "./index.css";
+
+const MOCK_JOIN_REQUESTS = Array.from({ length: 8 }, (_, i) => ({
+  id: i + 1,
+  name: `요청자 ${i + 1}`,
+  avatarUrl: "",
+}));
+
+const ITEMS_PER_PAGE = 3;
+
+const JoinRequestList = () => {
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const totalPages = Math.ceil(MOCK_JOIN_REQUESTS.length / ITEMS_PER_PAGE);
+  if (!totalPages) return null;
+  const startIndex = currentPage * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const currentRequests = MOCK_JOIN_REQUESTS.slice(startIndex, endIndex);
+
+  const handlePrev = () => {
+    setCurrentPage((prev) => Math.max(prev - 1, 0));
+  };
+
+  const handleNext = () => {
+    setCurrentPage((prev) => Math.min(prev + 1, totalPages - 1));
+  };
+
+  return (
+    <section
+      className={joinRequestSectionWrapper}
+      aria-labelledby="join-requst-title"
+    >
+      <div className={joinRequestHeaderWrapper}>
+        <div className={joinRequestHeadStyle}>
+          <h2 id="join-requst-title" className={joinRequestStyle}>
+            가입 요청
+          </h2>
+          <span className={countStyle}>{MOCK_JOIN_REQUESTS.length}</span>
+        </div>
+        <div>
+          <button
+            type="button"
+            className={buttonStyle}
+            onClick={handlePrev}
+            disabled={currentPage === 0}
+            aria-label="이전 가입 요청 목록"
+          >
+            <IcnBtnArrowLeft width={24} height={24} />
+          </button>
+          <button
+            type="button"
+            className={buttonStyle}
+            onClick={handleNext}
+            disabled={currentPage >= totalPages - 1}
+            aria-label="다음 가입 요청 목록"
+          >
+            <IcnBtnArrowRight width={24} height={24} />
+          </button>
+        </div>
+      </div>
+
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.ul
+          key={currentPage}
+          className={cardListWrapperStyle}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.15, ease: "easeInOut" }}
+        >
+          {currentRequests.map((request) => (
+            <li key={request.id}>
+              <ApprovalCard
+                key={request.id}
+                name={request.name}
+                avatarUrl={request.avatarUrl}
+              />
+            </li>
+          ))}
+        </motion.ul>
+      </AnimatePresence>
+    </section>
+  );
+};
+
+export default JoinRequestList;

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
@@ -24,6 +24,7 @@ const ITEMS_PER_PAGE = 3;
 
 const JoinRequestList = ({ groupName }: { groupName: string }) => {
   const [currentPage, setCurrentPage] = useState(0);
+  const [isDownDirection, setIsDownDirection] = useState(true);
 
   const totalPages = Math.ceil(MOCK_JOIN_REQUESTS.length / ITEMS_PER_PAGE);
   if (!totalPages) return null;
@@ -32,10 +33,12 @@ const JoinRequestList = ({ groupName }: { groupName: string }) => {
   const currentRequests = MOCK_JOIN_REQUESTS.slice(startIndex, endIndex);
 
   const handlePrev = () => {
+    setIsDownDirection(false);
     setCurrentPage((prev) => Math.max(prev - 1, 0));
   };
 
   const handleNext = () => {
+    setIsDownDirection(true);
     setCurrentPage((prev) => Math.min(prev + 1, totalPages - 1));
   };
 
@@ -73,26 +76,25 @@ const JoinRequestList = ({ groupName }: { groupName: string }) => {
         </div>
       </div>
 
-      <AnimatePresence mode="wait" initial={false}>
-        <motion.ul
-          key={currentPage}
-          className={cardListWrapperStyle}
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -10 }}
-          transition={{ duration: 0.15, ease: "easeInOut" }}
-        >
+      <motion.ul className={cardListWrapperStyle}>
+        <AnimatePresence mode="wait">
           {currentRequests.map((request) => (
-            <li key={request.id}>
+            <motion.li
+              key={request.id}
+              initial={{ opacity: 0.6, y: isDownDirection ? 3 : -3 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0.6, y: isDownDirection ? -3 : 3 }}
+              transition={{ duration: 0.15, ease: "easeInOut" }}
+            >
               <ApprovalCard
                 name={request.name}
                 groupName={groupName}
                 avatarUrl={request.avatarUrl}
               />
-            </li>
+            </motion.li>
           ))}
-        </motion.ul>
-      </AnimatePresence>
+        </AnimatePresence>
+      </motion.ul>
     </section>
   );
 };

--- a/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/JoinRequestList/index.tsx
@@ -14,10 +14,11 @@ import {
   joinRequestStyle,
 } from "./index.css";
 
-const MOCK_JOIN_REQUESTS = Array.from({ length: 8 }, (_, i) => ({
+export const MOCK_JOIN_REQUESTS = Array.from({ length: 8 }, (_, i) => ({
   id: i + 1,
   name: `요청자 ${i + 1}`,
   avatarUrl: "",
+  groupName: "스터디 이름",
 }));
 
 const ITEMS_PER_PAGE = 3;

--- a/apps/client/src/app/group/[groupId]/setting/components/MemberList/index.css.ts
+++ b/apps/client/src/app/group/[groupId]/setting/components/MemberList/index.css.ts
@@ -5,9 +5,6 @@ export const memberListWrapper = style({
   display: "flex",
   flexDirection: "column",
   gap: "2rem",
-
-  width: "80%",
-  padding: "4.8rem 4.2rem",
 });
 
 export const labelStyle = style({

--- a/apps/client/src/app/group/[groupId]/setting/components/MemberList/index.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/components/MemberList/index.tsx
@@ -15,7 +15,7 @@ const MemberList = ({ groupId }: { groupId: number }) => {
 
   return (
     <div className={memberListWrapper}>
-      <h1 className={labelStyle}>멤버 리스트</h1>
+      <h2 className={labelStyle}>멤버 리스트</h2>
       <MemberListProvider data={memberInfo}>
         <MemberListTable />
       </MemberListProvider>

--- a/apps/client/src/app/group/[groupId]/setting/components/index.css.ts
+++ b/apps/client/src/app/group/[groupId]/setting/components/index.css.ts
@@ -1,0 +1,10 @@
+import { style } from "@vanilla-extract/css";
+
+export const sectionWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "4rem",
+
+  width: "100%",
+  padding: "2rem 4.2rem",
+});

--- a/apps/client/src/app/group/[groupId]/setting/page.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/page.tsx
@@ -27,7 +27,7 @@ const GroupSettingPage = async ({
         <SettingSidebar info={groupInfo} code={inviteCode} />
       </Sidebar>
       <div className={sectionWrapper}>
-        <JoinRequestList />
+        <JoinRequestList groupName={groupInfo.name} />
         <MemberList groupId={+groupId} />
       </div>
     </section>

--- a/apps/client/src/app/group/[groupId]/setting/page.tsx
+++ b/apps/client/src/app/group/[groupId]/setting/page.tsx
@@ -4,6 +4,8 @@ import SettingSidebar from "@/app/group/[groupId]/setting/components/SettingSide
 import Sidebar from "@/common/component/Sidebar";
 import { sidebarWrapper } from "@/styles/shared.css";
 import { notFound } from "next/navigation";
+import JoinRequestList from "./components/JoinRequestList";
+import { sectionWrapper } from "./components/index.css";
 
 const GroupSettingPage = async ({
   params: { groupId },
@@ -20,12 +22,15 @@ const GroupSettingPage = async ({
   ]);
 
   return (
-    <main className={sidebarWrapper}>
+    <section className={sidebarWrapper}>
       <Sidebar>
         <SettingSidebar info={groupInfo} code={inviteCode} />
       </Sidebar>
-      <MemberList groupId={+groupId} />
-    </main>
+      <div className={sectionWrapper}>
+        <JoinRequestList />
+        <MemberList groupId={+groupId} />
+      </div>
+    </section>
   );
 };
 

--- a/apps/client/src/shared/component/GroupActionModal/Actions/index.tsx
+++ b/apps/client/src/shared/component/GroupActionModal/Actions/index.tsx
@@ -2,8 +2,8 @@ import Button from "@/common/component/Button";
 import { btnWrapper } from "./index.css";
 
 type ActionButtonsProps = {
-  onConfirm: () => void;
-  onReject: () => void;
+  onConfirm: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onReject: (e: React.MouseEvent<HTMLButtonElement>) => void;
   confirmText?: string;
   rejectText?: string;
 };

--- a/apps/client/src/shared/component/GroupActionModal/DecisionPrompt/index.tsx
+++ b/apps/client/src/shared/component/GroupActionModal/DecisionPrompt/index.tsx
@@ -14,6 +14,7 @@ export type DecisionPromptProps =
       variant: "applicant";
       applicantName: string;
       groupName: string;
+      count: number;
     };
 
 const getTexts = (props: DecisionPromptProps) => {
@@ -30,16 +31,30 @@ const getTexts = (props: DecisionPromptProps) => {
         title: <h1 className={metaStyle}>스터디를 수락하시겠어요?</h1>,
         description: `[${props.groupName}] 스터디에 가입을 요청합니다.\n스터디장의 수락 후 멤버가 될 수 있습니다.`,
       };
-    case "applicant":
+    case "applicant": {
+      const { count, applicantName, groupName } = props;
+      const isSingular = count === 1;
       return {
         title: (
           <h1 className={textStyle}>
-            <span className={metaStyle}>{props.applicantName}</span>님이 스터디
-            가입을 신청했습니다.
+            {isSingular ? (
+              <>
+                <span className={metaStyle}>{applicantName}님</span>이
+              </>
+            ) : (
+              <>
+                <span className={metaStyle}>{applicantName}님</span> 외{" "}
+                <span className={metaStyle}>{count - 1}명</span>이{" "}
+              </>
+            )}
+            {/** 홍길동님이 / 홍길동님 외 n명이 */}
+            스터디 가입을 신청했습니다.
           </h1>
         ),
-        description: `${props.applicantName}님께서 [${props.groupName}] 스터디에 가입을 요청했어요.\n거절한 요청은 다시 승인할 수 없습니다.`,
+        // 홍길동님께서 / 홍길동님 외 n명이 스터디에 ...
+        description: `${isSingular ? `${applicantName}님께서` : `${applicantName}님 외 ${count - 1}명이`} [${groupName}] 스터디에 가입을 요청했어요.\n거절한 요청은 다시 승인할 수 없습니다.`,
       };
+    }
     default:
       return { title: "", description: "" };
   }

--- a/apps/client/src/shared/component/GroupActionModal/index.css.ts
+++ b/apps/client/src/shared/component/GroupActionModal/index.css.ts
@@ -11,7 +11,7 @@ export const wrapper = style({
 
   width: "54rem",
   height: "65.6rem",
-  padding: "7.4rem 2.2rem 2.6rem",
+  padding: "8.4rem 2.2rem 2.6rem",
 
   borderRadius: "16px",
   backgroundColor: theme.color.bg,


### PR DESCRIPTION
## ✅ Done Task
  - [x] 가입 요청자 카드 컴포넌트 개발
  - [x] 카드 리스트 전환 애니메이션 적용
  - [x] 가입/승인 모달 적용

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
- Part 1: #461
- Part 2: #462
<details>
<summary>(참고용)part1 브랜치 정리 과정</summary>

분리 과정, 수정 적용 및 병합 계획은 다음과 같습니다.
**- 분리 과정**
1. 작업을 4개 part로 분리 (모달 리팩토링 / 코드 정리 / 가입 요청 리스트 / api 적용)
2. 새 브랜치를 만들고 #454 에서 가져올 커밋을 `git cherry-pick <commit-hash>`
(`<commit-hash>` 값은 각 브랜치가 아닌 저장소 기준으로 생성되므로 다른 브랜치도 사용 가능) 
3. cherry-pick한 것의 다음 커밋에 포함돼 있던 관련 변경 사항까지 포함 후 push (수작업)
(다음 커밋 처리는 `git cherry-pick --continue` / cherry-pick 종료는 `git cherry-pick --quit` / 취소는 `--abort`)
4. 다음 part의 브랜치는 이전 part의 브랜치를 기반으로 생성하여 2, 3번 반복
  
**- 수정 적용**
1. 이전 part의 브랜치에서 리뷰에 의해 수정 사항이 발생 (예: part1에 추가 커밋 발생)
2. 다음 part에 해당하는 모든 브랜치에서 앞의 브랜치를 rebase (예: part2는 `rebase part1`, part3은 `rebase part2` ... )

**- 병합 계획**
1. 모든 4개의 pr이 approve 상태
2. part1을 main에 병합
3. part2부터는 PR edit버튼으로 base 브랜치를 main으로 변경 (앞 part 브랜치가 아닌 main에 병합하도록 변경)
4. `git rebase -i main` 으로 이전 part 브랜치가 아닌 main 브랜치를 공통 조상으로 하도록 수정
5. main에 병합 및 마지막까지 3, 4 반복

수정 사항을 적용하는 과정이 조금 귀찮긴 하지만, 각 브랜치별 변경 사항 표시 및 안전한 병합을 위해서는 어쩔 수 없는 과정이긴 합니다.
</details>

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
가입 요청 리스트의 요구사항을 정리하면

  1. 리스트 아이템은 3개까지 표시
  2. 요청 리스트가 3개를 넘을 경우 <>버튼과 함께 리스트를 탐색할 수 있도록 제공

이렇게 2가지 입니다. <br>
- 두 요구사항 구현을 위해 **리스트 아이템의 부모 컴포넌트**에 다음 로직이 적용됐습니다.

```tsx
// group/[groupId]/setting/components/JoinRequestList/index.tsx
const ITEMS_PER_PAGE = 3;
...
// 3개 표시를 기준으로 몇 번째 페이지인지를 저장하는 state
const [currentPage, setCurrentPage] = useState(0);

const totalPages = useMemo(
  () => Math.ceil(JOIN_REQUESTS.length / ITEMS_PER_PAGE),
  [JOIN_REQUESTS.length],
);
// 전체 페이지 확인 후 페이지가 0이면(=요청자 없으면) 리스트 표시 안함
if (!totalPages) return null;

const startIndex = currentPage * ITEMS_PER_PAGE;
const currentRequests = JOIN_REQUESTS.slice(
  startIndex,
  startIndex + ITEMS_PER_PAGE,
);

const handlePrev = () => {
  setCurrentPage((prev) => Math.max(prev - 1, 0));
};

const handleNext = () => {
  setCurrentPage((prev) => Math.min(prev + 1, totalPages - 1));
};

return (
  ...
  <button onClick={handlePrev} disabled={currentPage === 0}>좌버튼</button>
  <button onClick={handleNext} disabled={currentPage >= totalPages - 1}>우버튼</button>
  ...
)
```

요구사항 외에도 페이지를 변경할 때 전환 효과가 없어 페이지가 바뀐 건지 잘 확인이 안돼서 애니메이션을 적용해보았습니다.
이번에는 추천 스터디 때와 같은 css가 아닌 `framer-motion`을 사용해 구현했습니다.
```tsx
// group/[groupId]/setting/components/JoinRequestList/index.tsx
// ul 태그인데 framer-motion의 애니메이션 props 사용 가능
<motion.ul className={cardListWrapperStyle}>
  // 핵심 컴포넌트 중 하나, 컴포넌트가 언마운트될 때도 애니메이션을 적용할 수 있게 해줌
  // exit 애니메이션이 끝날 때 까지 언마운트를 대기하는 기능 (애니메이션 충돌 방지)
  <AnimatePresence mode="wait">
    {currentRequests.map((request) => (
      <motion.li
        key={request.id}
        // initial: 처음 렌더링 & 애니메이션 시작 시 상태
        initial={{ opacity: 0.6, y: isDownDirection ? 3 : -3 }}
        // animate: 애니메이션 완료 상태 (transition기간 동안 initial→animate 전환됨)
        animate={{ opacity: 1, y: 0 }}
        // exit: 언마운트 시 상태 (언마운트되면 exit→initial→animate 순서로 전환됨)
        exit={{ opacity: 0.6, y: isDownDirection ? -3 : 3 }}
        transition={{ duration: 0.15, ease: "easeInOut" }}
      >
        <ApprovalCard
          name={request.name}
          groupName={groupName}
          avatarUrl={request.avatarUrl}
          groupId={groupId}
        />
      </motion.li>
    ))}
  </AnimatePresence>
</motion.ul>
```

결과적으로 이전/다음 페이지를 누르면 다음 목록으로 fade out-in 하며 전환되는 효과를 보여줍니다. 
initial과 exit에 있는 `y: isDownDirection`은 이전/다음 버튼이 서로 다른 방향으로 fade out-in 하는 게 좋겠다고 생각해서 추가한 것입니다.

다음으로 가입 요청자가 있다는 안내 모달의 요구사항은
1. 그룹 페이지 화면에 접속 시 표시
2. 너무 자주 표시되면 피곤하므로 세션 스토리지를 사용해서 한 번만 표시
3. refetch했을 때 갱신 됐으면 다시 표시
입니다. <br>
재표시 기준인 2, 3번은 제가 생각했을 때 가장 이상적인 재표시 시나리오라 생각하는데, 혹시 의견 있으시면 편하게 말씀해주세요!

- 1번 요구사항을 위해 `ExtensionAlertModal`의 구조를 사용했습니다.
`Controller` 컴포넌트를 놓고 이 컨트롤러가 모달의 표시 및 동작을 통제합니다.

- 2, 3번 요구사항을 위해 다음 로직을 적용했습니다.
```tsx
export const JoinRequestAlertModalController = ({
  groupName,
  groupId,
}: JoinRequestAlertModalControllerProps) => {
  // 요청자 배열 - 모달에 정보 표시를 위해 첫 번째 요청자의 이름과 사진 추출
  const { name, avatarUrl } = MOCK_JOIN_REQUESTS[0];

  // TODO: useSuspenseQuery로 isOpen 대체하기
  // + stale time 설정해서 refetch하고, 갱신됐으면 세션 스토리지 초기화해서 재표시
  const [isOpen, setIsOpen] = useState(false);
  // 여러 그룹의 알림 표시를 위해 개별 key 사용
  const sessionStorageKey = `joinRequestAlertShown-${groupId}`;

  useEffect(() => {
    // 세션 스토리지에서 표시 여부를 확인
    const hasBeenShown = sessionStorage.getItem(sessionStorageKey);
    if (!hasBeenShown) {
      setIsOpen(true);
    }
  }, [groupId, sessionStorageKey]);

  const handleApprove = () => {
    router.push(`/group/${groupId}/setting`);
    handleClose();
  };

  const handleClose = () => {
    setIsOpen(false);
    // 닫으면 표시 여부 체크
    sessionStorage.setItem(sessionStorageKey, "true");
  };
```
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
https://github.com/user-attachments/assets/25afebe8-e192-4c72-8d87-cf4e65c80083

