### PR TITLE
[ Fix ] scroll theme 적용

### DIFF
--- a/apps/client/src/app/[user]/components/LeftSidebar/index.css.ts
+++ b/apps/client/src/app/[user]/components/LeftSidebar/index.css.ts
@@ -9,7 +9,7 @@ export const sidebarWrapper = style({
   height: "72.5vh",
   overflowY: "auto",
 
-  ...scrollTheme.innerScrollbar,
+  ...scrollTheme.innerScrollbarY,
 });
 
 export const titleWrapper = style({

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/constant.tsx
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/constant.tsx
@@ -8,7 +8,7 @@ const SOLVED_STATUS_BASE_COLUMNS: TableDataType<SolutionsCurrentStatusResponse>[
       key: "rank",
       Header: () => "랭킹",
       Cell: (data) => data.rank,
-      width: 56,
+      width: 40,
     },
     {
       key: "total",
@@ -19,7 +19,7 @@ const SOLVED_STATUS_BASE_COLUMNS: TableDataType<SolutionsCurrentStatusResponse>[
           {data.totalPassedTime}
         </p>
       ),
-      width: 84,
+      width: 120,
     },
     {
       key: "id",
@@ -27,7 +27,7 @@ const SOLVED_STATUS_BASE_COLUMNS: TableDataType<SolutionsCurrentStatusResponse>[
       Cell: (data) => (
         <p className={tdStyle({ column: "nickname" })}>{data.nickname}</p>
       ),
-      width: 150,
+      width: 130,
       align: "left",
     },
   ];

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.css.ts
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/index.css.ts
@@ -1,4 +1,4 @@
-import { theme } from "@/styles/themes.css";
+import { scrollTheme, theme } from "@/styles/themes.css";
 import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
@@ -8,12 +8,12 @@ export const tableWrapper = style({
 });
 
 export const wrapper1Style = style({
-  width: "35%",
+  width: "320px",
   paddingBottom: "15px",
 });
 
 export const wrapper2Style = style({
-  width: "65%",
+  width: "calc(100% - 320px)",
 });
 
 export const table1Style = style({
@@ -28,6 +28,8 @@ export const table2Style = style({
   borderCollapse: "collapse",
   display: "block",
   overflowX: "scroll",
+
+  ...scrollTheme.innerScrollbarX,
 });
 
 export const theadStyle = style({

--- a/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/index.tsx
+++ b/apps/client/src/app/group/[groupId]/components/SolvedStatusSection/index.tsx
@@ -1,7 +1,7 @@
-import { SolvedStatusTableProvider } from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/provider";
 import type { SolutionsCurrentStatusResponse } from "@/app/api/type";
-import { titleStyle } from "@/app/group/[groupId]/page.css";
 import SolvedStatusTable from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable";
+import { SolvedStatusTableProvider } from "@/app/group/[groupId]/components/SolvedStatusSection/SolvedStatusTable/provider";
+import { titleStyle } from "@/app/group/[groupId]/page.css";
 import Empty from "@/shared/component/Empty";
 
 type SolvedStatusSectionProps = {

--- a/apps/client/src/app/group/[groupId]/page.tsx
+++ b/apps/client/src/app/group/[groupId]/page.tsx
@@ -45,10 +45,7 @@ const GroupDashboardPage = async ({
           <Ranking rankingData={rankingInfo} />
         </HydrationBoundary>
         <SolvedStatusSection
-          solutionsCurrentStatusInfo={[
-            ...solutionsCurrentStatusInfo,
-            ...solutionsCurrentStatusInfo,
-          ]}
+          solutionsCurrentStatusInfo={solutionsCurrentStatusInfo}
         />
       </div>
       <ExtensionAlertModalController domain="group" />

--- a/apps/client/src/shared/component/Table/TableElements/Header.tsx
+++ b/apps/client/src/shared/component/Table/TableElements/Header.tsx
@@ -19,12 +19,8 @@ const Header = <T,>({
   return (
     <thead className={clsx(theadClassName, tableHeaderStyle)}>
       <tr>
-        {columns.map(({ key, Header, width, align }) => (
-          <TableHead
-            key={key?.toString()}
-            className={thClassName}
-            width={width}
-          >
+        {columns.map(({ key, Header, align, ...props }) => (
+          <TableHead key={key?.toString()} className={thClassName} {...props}>
             <div className={headWrapper({ align })}>
               <Header />
             </div>

--- a/apps/client/src/shared/component/Table/TableElements/TableHead.tsx
+++ b/apps/client/src/shared/component/Table/TableElements/TableHead.tsx
@@ -11,7 +11,7 @@ const TableHead = ({ className, align, width, ...props }: TableHeadProps) => {
   return (
     <th
       className={clsx(tableHeadStyle({ align }), className)}
-      style={{ minWidth: `${width}px`, width: `${width}px` }}
+      style={width ? { minWidth: `${width}px`, width: `${width}px` } : {}}
       {...props}
     />
   );

--- a/apps/client/src/shared/type/table.ts
+++ b/apps/client/src/shared/type/table.ts
@@ -5,5 +5,5 @@ export type TableDataType<T> = {
   Header: FC;
   Cell: FC<T>;
   align?: "left" | "right";
-  width: number;
+  width?: number;
 };

--- a/apps/client/src/styles/themes.css.ts
+++ b/apps/client/src/styles/themes.css.ts
@@ -166,7 +166,7 @@ export const scrollTheme = createGlobalTheme(":root", {
       boxShadow: "none",
     },
   },
-  innerScrollbar: {
+  innerScrollbarY: {
     "&::-webkit-scrollbar": {
       width: "0.6rem",
     },
@@ -178,8 +178,26 @@ export const scrollTheme = createGlobalTheme(":root", {
       background: theme.color.mg3,
     },
     "&::-webkit-scrollbar-track": {
-      background: "transparent",
+      background: theme.color.mg6,
       boxShadow: "none",
+    },
+  },
+  innerScrollbarX: {
+    "&::-webkit-scrollbar": {
+      height: "1.4rem",
+    },
+    "&::-webkit-scrollbar-thumb": {
+      background: theme.color.mg4,
+      borderRadius: "0.6rem",
+      borderTop: `0.4rem solid ${theme.color.mg6}`,
+      borderBottom: `0.4rem solid ${theme.color.mg6}`,
+    },
+    "&::-webkit-scrollbar-thumb:active": {
+      background: theme.color.mg3,
+    },
+    "&::-webkit-scrollbar-track": {
+      borderRadius: "0.7rem",
+      background: theme.color.mg6,
     },
   },
 });


### PR DESCRIPTION
## ✅ Done Task
  - [x] 기존 scrollbar theme를 x와 y축으로 분리
  - [x] solved status table에 적용
  - [x] sovled status table에서 첫 테이블 속성 간격을 자연스럽게 수정
  - [x] table 컴포넌트 약간 수정 (width 속성 optional로)

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
```ts
// src/styles/themes.css.ts
  innerScrollbarX: {
    "&::-webkit-scrollbar": { // 전체 스크롤 바
      height: "1.4rem",
    },
    "&::-webkit-scrollbar-thumb": { // 스크롤 버튼
      background: theme.color.mg4,
      borderRadius: "0.6rem",
      borderTop: `0.4rem solid ${theme.color.mg6}`, // top, bottom으로 버튼 크기 조절
      borderBottom: `0.4rem solid ${theme.color.mg6}`, // 같은 색상의 border로 버튼을 가리는 trick밖에 안 됨
    },
    "&::-webkit-scrollbar-thumb:active": { // 스크롤 버튼 클릭 시 효과
      background: theme.color.mg3,
    },
    "&::-webkit-scrollbar-track": { // 스크롤 트랙, 전체 스크롤 바의 height를 상속 받음 (수정 불가)
      borderRadius: "0.7rem",
      background: theme.color.mg6,
    },
  },
```
## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
기존에 user page의 좌측 사이드바에 있던 스크롤 테마를 적용하려고 보니 y축 전용으로 만들어 놔서 스타일이 전혀 안 맞길래 x, y용으로 분리했습니다.
동일한 스크롤 테마가 필요한 컴포넌트라면 다음과 같이 사용하시면 됩니다.
```ts
export const tableStyle = style({
  // ...기타 css 속성들
  overflowX: "scroll",

  ...scrollTheme.innerScrollbarX, // 요 부분
});
```

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
 - 데이터 많을 때 (가짜 데이터로 구현)
<img width="1250" height="744" alt="scrollbar1" src="https://github.com/user-attachments/assets/9efa43ac-2ff8-4b9b-acbb-32ec9dd65265" />

 - 하나씩 있을 때
<img width="1003" height="395" alt="scrollbar2" src="https://github.com/user-attachments/assets/7cab6ed3-5bc5-4d5d-b765-6813b5d6c619" />
