### PR TITLE
[ Fix ] prefetchQueries 및 pagination 수정, api 업데이트

### DIFF
--- a/apps/client/src/app/[user]/my-solved/page.tsx
+++ b/apps/client/src/app/[user]/my-solved/page.tsx
@@ -22,7 +22,10 @@ const MySolvedPage = () => {
     currentPage: inProgressPage,
     totalPages: inProgressTotalPages,
     setCurrentPage: setInProgressPage,
-  } = usePaginationQuery(useInProgressMySolutionsQueryObject());
+  } = usePaginationQuery({
+    ...useInProgressMySolutionsQueryObject(),
+    searchParam: "inProgress",
+  });
   const inProgressList = inProgressData?.content || [];
 
   const {
@@ -30,7 +33,10 @@ const MySolvedPage = () => {
     currentPage: expiredPage,
     totalPages: expiredTotalPages,
     setCurrentPage: setExpiredPage,
-  } = usePaginationQuery(useExpiredMySolutionsQueryObject());
+  } = usePaginationQuery({
+    ...useExpiredMySolutionsQueryObject(),
+    searchParam: "expired",
+  });
   const expiredList = expiredData?.content || [];
 
   return (

--- a/apps/client/src/app/api/groups/index.ts
+++ b/apps/client/src/app/api/groups/index.ts
@@ -239,45 +239,58 @@ export const postProblem = (groupId: number, body: ProblemRequest) => {
   return response;
 };
 
-export const getInProgressProblems = async ({
+export const getProblems = async ({
   groupId,
+  status,
   page,
   size,
-  isUnsolvedOnly,
-}: GetProblemRequest) => {
+  unsolvedOnly,
+}: GetProblemRequest): Promise<ProblemListResponse> => {
+  const searchParams = {
+    status,
+    page,
+    size,
+    unsolvedOnly: `${unsolvedOnly}`,
+  };
+
   const response = await kyJsonWithTokenInstance
-    .get<ProblemListResponse>(
-      `api/groups/${groupId}/problems/in-progress?unsolved-only=${isUnsolvedOnly}&page=${page}&size=${size}`,
-    )
-    .json();
+    .get(`api/groups/${groupId}/problems`, {
+      searchParams,
+    })
+    .json<ProblemListResponse>();
 
   return response;
 };
 
-export const getExpiredProblems = async ({
-  groupId,
-  page,
-  size,
-}: GetProblemRequest) => {
-  const response = await kyJsonWithTokenInstance
-    .get<ProblemListResponse>(
-      `api/groups/${groupId}/problems/expired?page=${page}&size=${size}`,
-    )
-    .json();
+export const getInProgressProblems = async (
+  props: Omit<GetProblemRequest, "status">,
+) => {
+  const response = await getProblems({
+    ...props,
+    status: "IN_PROGRESS",
+  });
 
   return response;
 };
 
-export const getQueuedProblems = async ({
-  groupId,
-  page,
-  size,
-}: GetProblemRequest) => {
-  const response = await kyJsonWithTokenInstance
-    .get<ProblemListResponse>(
-      `api/groups/${groupId}/problems/queued?page=${page}&size=${size}`,
-    )
-    .json();
+export const getExpiredProblems = async (
+  props: Omit<GetProblemRequest, "status" | "unsolvedOnly">,
+) => {
+  const response = await getProblems({
+    ...props,
+    status: "EXPIRED",
+  });
+
+  return response;
+};
+
+export const getQueuedProblems = async (
+  props: Omit<GetProblemRequest, "status" | "unsolvedOnly">,
+) => {
+  const response = await getProblems({
+    ...props,
+    status: "QUEUED",
+  });
 
   return response;
 };

--- a/apps/client/src/app/api/problems/type.ts
+++ b/apps/client/src/app/api/problems/type.ts
@@ -34,7 +34,8 @@ export type EditProblemRequest = {
 
 export type GetProblemRequest = {
   groupId: number;
+  status: "IN_PROGRESS" | "EXPIRED" | "QUEUED";
   page: number;
   size: number;
-  isUnsolvedOnly?: boolean;
+  unsolvedOnly?: boolean;
 };

--- a/apps/client/src/app/group/[groupId]/problem-list/page.tsx
+++ b/apps/client/src/app/group/[groupId]/problem-list/page.tsx
@@ -54,7 +54,7 @@ const ProblemListPage = ({
         groupId: +groupId,
         page,
         size: 3,
-        isUnsolvedOnly: isUnsolvedOnlyChecked,
+        unsolvedOnly: isUnsolvedOnlyChecked,
       }),
   });
   const inProgressList = inProgressData?.content;

--- a/apps/client/src/shared/hook/usePaginationQuery.ts
+++ b/apps/client/src/shared/hook/usePaginationQuery.ts
@@ -23,14 +23,14 @@ export type BasePaginationQueryProps<T> = {
 
 // URL 동기화를 사용하지 않을 경우의 props
 type UrlSyncDisabled = {
-  isUrlSync?: false;
+  isUrlSync: false;
   searchParam?: never;
   initialPage?: number;
 };
 
 // URL 동기화를 사용할 경우의 props
 type UrlSyncEnabled = {
-  isUrlSync: true;
+  isUrlSync?: true;
   searchParam?: string;
   initialPage?: never; // isUrlSync가 true일 때 initialPage 사용 방지
 };
@@ -54,7 +54,7 @@ const useLocalPaginationState = (initialPage = 1): PaginationState => {
 /**
  * 데이터 fetching과 페이지네이션 상태 관리를 통합한 훅
  */
-export const usePaginationQuery = <T>({
+export const usePaginationQuery = <T extends PaginationResponse>({
   queryKey,
   queryFn,
   isUrlSync = true,

--- a/apps/client/src/shared/util/prefetch.ts
+++ b/apps/client/src/shared/util/prefetch.ts
@@ -17,6 +17,10 @@ const getQueryClient = cache(() => {
   });
 });
 
+/**
+ * @param options - prefetchQuery에 전달할 옵션 객체
+ * @param returnClient - true일 경우 QueryClient 인스턴스를, false(기본값)일 경우 DehydratedState를 반환
+ */
 export async function prefetchQuery<
   TQueryFnData = unknown,
   TError = unknown,
@@ -47,32 +51,34 @@ export async function prefetchQuery(
   return dehydrate(queryClient);
 }
 
+/**
+ * @param options - prefetchQuery에 전달할 옵션 객체의 배열
+ * @param returnClient - true일 경우 QueryClient 인스턴스를, false(기본값)일 경우 DehydratedState를 반환
+ */
 export async function prefetchQueries<
-  TQueryFnData = unknown,
-  TError = unknown,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
+  T extends FetchQueryOptions
 >(
-  queries: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>[],
+  options: readonly T[],
   returnClient: true,
 ): Promise<QueryClient>;
 export async function prefetchQueries<
-  TQueryFnData = unknown,
-  TError = unknown,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
+  T extends FetchQueryOptions
 >(
-  queries: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>[],
+  options: readonly T[],
   returnClient?: false,
 ): Promise<DehydratedState>;
-export async function prefetchQueries(
-  queries: FetchQueryOptions<unknown, unknown, unknown, QueryKey>[],
+export async function prefetchQueries<
+  T extends FetchQueryOptions
+>(
+  options: readonly T[],
   returnClient?: boolean,
 ): Promise<QueryClient | DehydratedState> {
   const queryClient = getQueryClient();
+
   await Promise.all(
-    queries.map((options) => queryClient.prefetchQuery(options)),
+    options.map((option) => queryClient.prefetchQuery(option)),
   );
+
   if (returnClient) {
     return queryClient;
   }

--- a/apps/client/src/shared/util/prefetch.ts
+++ b/apps/client/src/shared/util/prefetch.ts
@@ -55,29 +55,21 @@ export async function prefetchQuery(
  * @param options - prefetchQuery에 전달할 옵션 객체의 배열
  * @param returnClient - true일 경우 QueryClient 인스턴스를, false(기본값)일 경우 DehydratedState를 반환
  */
-export async function prefetchQueries<
-  T extends FetchQueryOptions
->(
+export async function prefetchQueries<T extends FetchQueryOptions>(
   options: readonly T[],
   returnClient: true,
 ): Promise<QueryClient>;
-export async function prefetchQueries<
-  T extends FetchQueryOptions
->(
+export async function prefetchQueries<T extends FetchQueryOptions>(
   options: readonly T[],
   returnClient?: false,
 ): Promise<DehydratedState>;
-export async function prefetchQueries<
-  T extends FetchQueryOptions
->(
+export async function prefetchQueries<T extends FetchQueryOptions>(
   options: readonly T[],
   returnClient?: boolean,
 ): Promise<QueryClient | DehydratedState> {
   const queryClient = getQueryClient();
 
-  await Promise.all(
-    options.map((option) => queryClient.prefetchQuery(option)),
-  );
+  await Promise.all(options.map((option) => queryClient.prefetchQuery(option)));
 
   if (returnClient) {
     return queryClient;


### PR DESCRIPTION
## ✅ Done Task
  - [x] `prefetchQueries` 수정
  - [x] `usePaginationQuery`의 타입을 수정하여 정확하게 타입 추론 (url 동기화 타입 or useState 타입)
  - [x] my-solved page의 페이지네이션 정상화 및 모달 열기 시 page 1로 변경되는 버그 수정
  - [x] 서버 측 api/groups/${groupId}/problems api 통합에 따라 클라이언트 측도 업데이트

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
1. ### prefetchQueries
    - as-is
    ```ts
    export async function prefetchQueries<
      TQueryFnData = unknown,
      TError = unknown,
      TData = TQueryFnData,
      TQueryKey extends QueryKey = QueryKey,
    >(
      options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>[], 
      returnClient: false,
    ) { ... }
    ```
    이전에는 제네릭을 그대로 배열의 타입에 넣어버리도록 만들어 놔서 배열 전체의 타입이 첫 번째 요소의 타입으로 정해졌습니다. 그래서 2번째 배열 인덱스부터 다른 타입의 queryOptions가 들어가면 타입 에러가 발생합니다.
    
    - to-be : 
    ```ts
    export async function prefetchQueries<
      T extends FetchQueryOptions
    >(
      options: readonly T[],
      returnClient: true,
    ) { ... }
    ```
    애초에 제네릭이 없는 queryClient나 dehydrated state를 return하며 호출하는 곳에서도 타입을 신경쓰지 않기 때문에 제네릭은 그냥 작동하게만 만들면 되는 부분이었습니다.
2. ### usePaginationQuery - type
    ```ts
      const {
        data: inProgressData,
        currentPage: inProgressPage,
        totalPages: inProgressTotalPages,
        setCurrentPage: setInProgressPage,
      } = usePaginationQuery({
        ...useInProgressMySolutionsQueryObject(),
        searchParam: "inProgress", // <- 이전에 누락했던 부분
      });
    ```
    페이지네이션 searchParam은 `QueryObject`의 `querykey[0]`을 기본값으로 사용하게 했었습니다. 그런데 위 `QueryObject`의 경우는 [0]이 `user`라서 바로 아래 있는 `expiredMySolution`과 searchParam이 겹치게 됩니다. 이럴 때를 대비하여 만든 것이 searchParam 옵션입니다.
    그런데 이전에 type을 잘못 만들어 놔서 이걸 사용할 때 굳이 기본값이 true인 isUrlSync 옵션도 명시해야 했던 문제가 있어서 이를 해결하였습니다. (`{ ...useInProgressMySolutionsQueryObject(), searchParam: "inProgress", isUrlSync: true }`로 써야 했음)
    - as-is
    ```ts
    // useState를 사용할 경우의 props
    type UrlSyncDisabled = {
      isUrlSync?: false;
      searchParam?: never;
      initialPage?: number;
    };
    // URL 동기화를 사용할 경우의 props
    type UrlSyncEnabled = {
      isUrlSync: true;
      searchParam?: string;
      initialPage?: never; // isUrlSync가 true일 때 initialPage 사용 방지
    };
    export type UsePaginationQueryProps<T> = BasePaginationQueryProps<T> & (UrlSyncDisabled | UrlSyncEnabled);
    ```
    `Enabled` 타입에서 isUrlSync가 옵셔널 기호(?)없이 정의된 것에 의해 searchParam을 사용할 경우 isUrlSync는 무조건 true 값을 명시적으로 넣어줘야 했습니다.
    - to-be
    ```ts
    // useState를 사용할 경우의 props
    type UrlSyncDisabled = {
      isUrlSync: false;
      ...
    };
    // URL 동기화를 사용할 경우의 props
    type UrlSyncEnabled = {
      isUrlSync?: true;
      ...
    };
    ```
    isUrlSync의 옵셔널을 교체함으로써 `Enabled`를 사용할 때는 searchParam만 쓸 수 있도록 하고, `Disabled`를 사용할 때는 searchParam은 사용 불가 및 initialPage를 사용할 수 있고 동시에 `isUrlSync: false`를 명시해야 합니다. 
    
3. ### usePaginationQuery - 모달 열기 시 1 page로 변경되는 이슈
    기존 페이지네이션 값은 useMemo를 사용하여 searchParam이 바뀌면 바로 계산하여 동기화 하도록 만들어져 있었습니다. 그에 따라 `parallel & intercepting routes`를 적용한 모달을 열면 페이지네이션 search param이 url에서 없어지고 동시에 `useSearchParam`에 의해 리렌더링 되며 페이지 값을 계산하는데, search param 값이 없으면 1페이지를 표시하게 해 놓았기에 1페이지가 되어 버립니다. 이를 해결하려면 두 가지 방법이 있습니다.
      1. search param을 유지하도록 `<Link>`를 래핑하거나 `router.push`를 래핑하기
      이는 변경 사항이 너무 많을 것 같아 바로 버렸습니다.
      2. 페이지네이션 search param 값이 바뀔 때 search param이 없어져도 페이지를 변경 하지 않도록 하는 로직 적용
      한마디로 모달 페이지를 띄울 때는 기존과 달리 `setCurrentPage`를 호출하지 않도록 하였습니다.
      ```typescript
      // useState로 변경했으므로 state 초기 값에서 바로 엣지 케이스에 대응해야 함
      const [currentPage, _setCurrentPage] = useState(() => {
        // parseSafePositiveInteger는 엣지 케이스를 1이나 number로 바꿔주는 함수
        return parseSafePositiveInteger(searchParams.get(queryKey));
      });
      useEffect(() => {
        // 의존성 배열의 searchParams에 의해 url 변경 시 useEffect가 호출됨
        // search param이 존재하고 && state와 페이지가 달라졌으면 setState 호출
        const pageFromUrlQuery = searchParams.get(queryKey);
        if (pageFromUrlQuery !== null) {
          const pageFromUrl = parseSafePositiveInteger(pageFromUrlQuery);
          if (pageFromUrl !== currentPage) {
            _setCurrentPage(pageFromUrl);
          }
        }
      }, [searchParams, queryKey, currentPage]);
      ```

4. ### 그룹 페이지 - 문제 리스트 api 업데이트
    저번 my-solved api때와 마찬가지로 `inProgress`, `expired`, `queued`를 각각 별개의 api 함수로 만들었습니다.
    status 옵션을 인자로 넣기 보다는 함수명에서 명시하는 편이 빠르게 확인할 수 있어 편하기 때문이며, `Omit`을 통해 각 api가 필요로 하는 옵셔널 인자에 맞게 타입을 정해주기 편하다는 장점도 있습니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->