### PR TITLE
[ Fix ] 스크롤 영역 변경 및 sticky 적용

### DIFF
--- a/apps/client/src/app/[user]/components/LeftSidebar/index.css.ts
+++ b/apps/client/src/app/[user]/components/LeftSidebar/index.css.ts
@@ -2,14 +2,13 @@ import { scrollTheme, theme } from "@/styles/themes.css";
 import { style, styleVariants } from "@vanilla-extract/css";
 
 export const sidebarWrapper = style({
+  position: "sticky",
   display: "flex",
   flexDirection: "column",
   gap: "1.6rem",
 
-  height: "72.5vh",
-  overflowY: "auto",
-
-  ...scrollTheme.innerScrollbarY,
+  height: "100%",
+  top: 0,
 });
 
 export const titleWrapper = style({
@@ -93,6 +92,9 @@ export const studyListContainerStyle = style({
   flexDirection: "column",
 
   marginLeft: "2px",
+
+  overflowY: "auto",
+  ...scrollTheme.innerScrollbarY,
 });
 
 export const studyTitleWrapper = style({

--- a/apps/client/src/app/[user]/components/index.css.ts
+++ b/apps/client/src/app/[user]/components/index.css.ts
@@ -33,5 +33,9 @@ export const userHomeWrapper = style({
 export const leftSidebarStyle = style({
   display: "flex",
   justifyContent: "center",
-  padding: "4rem 0.4rem 4rem 2.4rem",
+  padding: "4rem 0.4rem 0.4rem 2.4rem",
+
+  position: "sticky",
+  top: 0,
+  height: "calc(100vh - 14.4rem)",
 });


### PR DESCRIPTION
## ✅ Done Task
  - [x] 스터디 리스트 스크롤 영역 변경
  - [x] 스터디 리스트 영역 화면 끝까지 나오게 수정
  - [x] 스터디 리스트에 sticky 적용 (피드를 읽기 위해 아래로 스크롤하면 사이드바가 따라오게)

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
<div style="display:flex;flex-direction:row;">
  <img width="300" height="384" alt="image" src="https://github.com/user-attachments/assets/59448b63-77b0-42ab-a47c-c37e2f5a4111" />
  <img width="300" height="384" alt="image" src="https://github.com/user-attachments/assets/cd7d3ed4-f346-4d7d-823e-4f03a794239a" />
</div>

스크롤하면 두번째 사진처럼 좌측 스터디 리스트의 맨 아래 부분이 배경색과 다르게 나와서 어색한데 어떻게 할까요?
1. 상단 메뉴까지 같이 sticky 적용 (스크롤 했을 때 상단 메뉴가 나와야 한다면)
2. 스크롤하면 스터디 리스트의 height를 늘리는 코드 적용 (스크롤 했을 때 상단 메뉴가 안 나와야 한다면)

- 1번 예시
<img width="950" height="480" alt="image" src="https://github.com/user-attachments/assets/89fc5ab8-5bdf-4d47-bbf7-e31b7e6e2173" />

- 2번 예시
<img width="950" height="480" alt="image" src="https://github.com/user-attachments/assets/06f5616e-83d6-4131-894a-a57f202e18da" />

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->