### PR TITLE
[ Fix ] 문제 등록 시 올바르게 탭 변경

### DIFF
--- a/apps/client/src/app/api/groups/mutation.ts
+++ b/apps/client/src/app/api/groups/mutation.ts
@@ -22,6 +22,7 @@ import { userQueryKey } from "@/app/api/users/query";
 import { useToast } from "@/common/hook/useToast";
 import { HTTP_ERROR_STATUS } from "@/shared/constant/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isBefore, startOfTomorrow } from "date-fns";
 import type { HTTPError } from "ky";
 import { useSession } from "next-auth/react";
 import { useParams, useRouter } from "next/navigation";
@@ -287,7 +288,9 @@ export const usePostProblemMutation = (groupId: number) => {
       ]);
       (
         document.querySelector(
-          +variables.startDate < Date.now() ? "#tab-1" : "#tab-2",
+          isBefore(variables.startDate, startOfTomorrow())
+            ? "#tab-1"
+            : "#tab-2",
         ) as HTMLLIElement
       )?.click();
 

--- a/apps/client/src/app/api/groups/query.ts
+++ b/apps/client/src/app/api/groups/query.ts
@@ -50,6 +50,10 @@ export const groupQueryKey = {
     ...groupQueryKey.problems(groupId),
     "queued",
   ],
+  expiredProblems: (groupId: number) => [
+    ...groupQueryKey.problems(groupId),
+    "expired",
+  ],
   search: (params: SearchRequest) => [...groupQueryKey.all(), "search", params],
   joinRequests: (groupId: number) =>
     [...groupQueryKey.detail(groupId), "join-requests"] as const,

--- a/apps/client/src/app/group/[groupId]/problem-list/components/PendingList/index.tsx
+++ b/apps/client/src/app/group/[groupId]/problem-list/components/PendingList/index.tsx
@@ -17,6 +17,7 @@ const PendingList = ({ groupId }: { groupId: number }) => {
   } = usePaginationQuery({
     queryKey: groupQueryKey.queuedProblems(groupId),
     queryFn: (page) => getQueuedProblems({ groupId, page, size: 7 }),
+    searchParam: "queued",
   });
   const queuedList = queuedData?.content;
 

--- a/apps/client/src/app/group/[groupId]/problem-list/components/PendingList/index.tsx
+++ b/apps/client/src/app/group/[groupId]/problem-list/components/PendingList/index.tsx
@@ -1,4 +1,5 @@
 import { getQueuedProblems } from "@/app/api/groups";
+import { groupQueryKey } from "@/app/api/groups/query";
 import PendingListItem from "@/app/group/[groupId]/problem-list/components/PendingList/Item";
 import {
   listStyle,
@@ -14,7 +15,7 @@ const PendingList = ({ groupId }: { groupId: number }) => {
     totalPages: queuedTotalPages,
     setCurrentPage: setQueuedPage,
   } = usePaginationQuery({
-    queryKey: ["queuedProblem", groupId],
+    queryKey: groupQueryKey.queuedProblems(groupId),
     queryFn: (page) => getQueuedProblems({ groupId, page, size: 7 }),
   });
   const queuedList = queuedData?.content;

--- a/apps/client/src/app/group/[groupId]/problem-list/page.tsx
+++ b/apps/client/src/app/group/[groupId]/problem-list/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { getExpiredProblems, getInProgressProblems } from "@/app/api/groups";
-import { useGroupRoleQueryObject } from "@/app/api/groups/query";
+import { groupQueryKey, useGroupRoleQueryObject } from "@/app/api/groups/query";
 import CheckBox from "@/common/component/CheckBox";
 import Sidebar from "@/common/component/Sidebar";
 import TabGroup from "@/common/component/Tab";
@@ -45,8 +45,7 @@ const ProblemListPage = ({
     setCurrentPage: setInProgressPage,
   } = usePaginationQuery({
     queryKey: [
-      "inProgressProblem",
-      +groupId,
+      ...groupQueryKey.inProgressProblems(+groupId),
       { unsolved: isUnsolvedOnlyChecked },
     ],
     queryFn: (page) =>
@@ -65,7 +64,7 @@ const ProblemListPage = ({
     totalPages: expiredTotalPages,
     setCurrentPage: setExpiredPage,
   } = usePaginationQuery({
-    queryKey: ["expiredProblem", +groupId],
+    queryKey: groupQueryKey.expiredProblems(+groupId),
     queryFn: (page) =>
       getExpiredProblems({
         groupId: +groupId,

--- a/apps/client/src/app/group/[groupId]/problem-list/page.tsx
+++ b/apps/client/src/app/group/[groupId]/problem-list/page.tsx
@@ -55,6 +55,7 @@ const ProblemListPage = ({
         size: 3,
         unsolvedOnly: isUnsolvedOnlyChecked,
       }),
+      searchParam: "inProgress"
   });
   const inProgressList = inProgressData?.content;
 
@@ -71,6 +72,7 @@ const ProblemListPage = ({
         page,
         size: 3,
       }),
+      searchParam: "expired"
   });
   const expiredList = expiredData?.content;
 

--- a/apps/client/src/app/group/[groupId]/problem-list/page.tsx
+++ b/apps/client/src/app/group/[groupId]/problem-list/page.tsx
@@ -55,7 +55,7 @@ const ProblemListPage = ({
         size: 3,
         unsolvedOnly: isUnsolvedOnlyChecked,
       }),
-      searchParam: "inProgress"
+    searchParam: "inProgress",
   });
   const inProgressList = inProgressData?.content;
 
@@ -72,7 +72,7 @@ const ProblemListPage = ({
         page,
         size: 3,
       }),
-      searchParam: "expired"
+    searchParam: "expired",
   });
   const expiredList = expiredData?.content;
 


### PR DESCRIPTION
## ✅ Done Task
  - [x] 시간 계산 로직 수정
  - [x] 누락된 queryKey 컨벤션 적용 (문제를 등록해도 새로고침해야 화면에 나오던 버그)
    - [x] queryKey 컨벤션 적용에 따라 페이지네이션 searchParam 추가

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 시간 계산 로직
기존의 시간 계산 로직은 `startDate`를 `Date.now()`와 비교했었는데, 문제 등록 폼이 시간을 받지 않기 때문에 `Date.now()`와 비교해서는 안됐습니다. 날짜까지만 입력받는 문제 등록 폼의 맥락에 맞게 `date-fns`의 `isBefore`로 내일 날짜와 비교하도록 수정했습니다. (12/29 기준, `startDate >= 12/30`면 대기중인 문제 탭으로 이동)

- queryKey 컨벤션 누락
`query` 부분은 `["queuedProblem", groupId]` 와 같이 옛날 방식으로 작성된 `queryKey`를 사용하고 있는 반면, `mutation`에서는 `queryKey` 컨벤션인 `groupQueryKey`를 사용하고 있습니다. 이에 따른 둘 간의 불일치로 인해 문제를 등록해도 `invalidate`하지 못하는 일이 발생하고 있었습니다. 그래서 잘 수정했습니다.

- 페이지네이션 searchParam 적용
`usePaginationQuery`에 `queryKey` 컨벤션을 적용함에 따라 페이지네이션 용 `searchParam`이 `groupQueryKey`의 0번 인덱스인 `group`으로 적용되므로 각각에 맞는 searchParam을 따로 적용해 주었습니다.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->