### PR TITLE
[ Refactor ] home 화면 QA 

### DIFF
--- a/apps/client/src/app/@modal/(...)group/[groupId]/solved-detail/components/CommentSection/index.tsx
+++ b/apps/client/src/app/@modal/(...)group/[groupId]/solved-detail/components/CommentSection/index.tsx
@@ -45,17 +45,15 @@ const CommentSection = ({ solutionId }: CommentSectionProps) => {
     <div className={sectionWrapper}>
       <ul className={ulStyle} ref={commentRef}>
         <CommentsProvider solutionId={+solutionId}>
-          {comments
-            ?.sort((a, b) => +new Date(a.createdAt) - +new Date(b.createdAt))
-            .map((item) => (
-              <CommentBox
-                key={item.commentId}
-                variant="detail"
-                onDelete={deleteMutate}
-                isMine={item.writerNickname === session?.user?.nickname}
-                {...item}
-              />
-            ))}
+          {comments?.map((item) => (
+            <CommentBox
+              key={item.commentId}
+              variant="detail"
+              onDelete={deleteMutate}
+              isMine={item.writerNickname === session?.user?.nickname}
+              {...item}
+            />
+          ))}
         </CommentsProvider>
       </ul>
       <form onSubmit={handleCommentSubmit} className={commentInputStyle}>

--- a/apps/client/src/app/[user]/components/CommentInput/index.css.ts
+++ b/apps/client/src/app/[user]/components/CommentInput/index.css.ts
@@ -7,8 +7,8 @@ export const leaveCommentWrapper = style({
   padding: "0.8rem 2rem",
 });
 
-export const commentFormStyle = style({ width: "100%" });
-
-export const commentInputStyle = style({
-  marginLeft: "1.2rem",
+export const enterSvgStyle = style({
+  marginRight: "0.4rem",
 });
+
+export const commentFormStyle = style({ width: "100%", marginLeft: "1.2rem" });

--- a/apps/client/src/app/[user]/components/CommentInput/index.tsx
+++ b/apps/client/src/app/[user]/components/CommentInput/index.tsx
@@ -2,7 +2,7 @@
 
 import {
   commentFormStyle,
-  commentInputStyle,
+  enterSvgStyle,
   leaveCommentWrapper,
 } from "@/app/[user]/components/CommentInput/index.css";
 import { useCommentMutation } from "@/app/api/comments/mutation";
@@ -40,7 +40,7 @@ const CommentInput = ({
 
   return (
     <section className={leaveCommentWrapper}>
-      <IcnEnter width={24} height={24} aria-hidden />
+      <IcnEnter width={24} height={24} aria-hidden className={enterSvgStyle} />
       <Avatar
         size="small"
         alt={`${data?.user?.nickname}님의 프로필 사진`}
@@ -50,7 +50,6 @@ const CommentInput = ({
         <Input
           placeholder="의견을 남겨주세요."
           aria-label="풀이에 대한 의견을 남기는 input"
-          className={commentInputStyle}
           value={comment}
           onChange={handleCommentChange}
         />

--- a/apps/client/src/app/[user]/components/CommentInput/index.tsx
+++ b/apps/client/src/app/[user]/components/CommentInput/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   commentFormStyle,
   commentInputStyle,
@@ -7,21 +9,19 @@ import { useCommentMutation } from "@/app/api/comments/mutation";
 import { IcnEnter } from "@/asset/svg";
 import Avatar from "@/common/component/Avatar";
 import Input from "@/common/component/Input";
+import { useSession } from "next-auth/react";
 import { useState } from "react";
 
 interface CommentInputProps {
-  profileUrl?: string;
-  nickname?: string;
   solutionId: number;
   onCommentCountPlus: () => void;
 }
 
 const CommentInput = ({
-  profileUrl,
-  nickname,
   solutionId,
   onCommentCountPlus,
 }: CommentInputProps) => {
+  const { data } = useSession();
   const [comment, setComment] = useState("");
 
   const { mutate: postComment } = useCommentMutation(solutionId);
@@ -43,8 +43,8 @@ const CommentInput = ({
       <IcnEnter width={24} height={24} aria-hidden />
       <Avatar
         size="small"
-        alt={`${nickname}님의 프로필 사진`}
-        src={profileUrl}
+        alt={`${data?.user?.nickname}님의 프로필 사진`}
+        src={data?.user?.profileImage}
       />
       <form onSubmit={handleCommentSubmit} className={commentFormStyle}>
         <Input

--- a/apps/client/src/app/[user]/components/FeedItem/index.css.ts
+++ b/apps/client/src/app/[user]/components/FeedItem/index.css.ts
@@ -110,3 +110,4 @@ export const moreCommentButtonStyle = style({
 
   cursor: "pointer",
 });
+

--- a/apps/client/src/app/[user]/components/FeedItem/index.css.ts
+++ b/apps/client/src/app/[user]/components/FeedItem/index.css.ts
@@ -97,9 +97,11 @@ export const moreCommentWrapper = style({
   padding: "0.6rem 0",
 
   color: "inherit",
-  ...theme.font.Caption1_R_12,
 });
 
+export const moreCommentTextStyle = style({
+  ...theme.font.Caption1_R_12,
+});
 export const moreCommentButtonStyle = style({
   padding: "0.2rem 0.8rem",
 
@@ -107,7 +109,7 @@ export const moreCommentButtonStyle = style({
   borderRadius: "4px",
 
   color: "inherit",
+  ...theme.font.Caption1_R_12,
 
   cursor: "pointer",
 });
-

--- a/apps/client/src/app/[user]/components/FeedItem/index.tsx
+++ b/apps/client/src/app/[user]/components/FeedItem/index.tsx
@@ -59,9 +59,10 @@ const FeedItem = ({ solutionId, groupId }: FeedItemProps) => {
       ],
     });
 
-  const displayedComments = comments
-    ?.toReversed()
-    .slice(comments.length - displayedCommentCount, comments.length);
+  const displayedComments = comments?.slice(
+    comments.length - displayedCommentCount,
+    comments.length,
+  );
 
   // 피드에 뜨게한 댓글 찾기 - 나를 제외한 최신 댓글
   const triggerComment = useMemo(

--- a/apps/client/src/app/[user]/components/FeedItem/index.tsx
+++ b/apps/client/src/app/[user]/components/FeedItem/index.tsx
@@ -16,6 +16,7 @@ import {
   infoWrapper,
   moreCommentButtonStyle,
   moreCommentContainer,
+  moreCommentTextStyle,
   moreCommentWrapper,
   nameStyle,
   studyNameStyle,
@@ -145,7 +146,9 @@ const FeedItem = ({ solutionId, groupId }: FeedItemProps) => {
             className={moreCommentContainer}
           >
             <div className={moreCommentWrapper}>
-              <span>{`댓글 +${comments?.length - displayedCommentCount}`}</span>
+              <span
+                className={moreCommentTextStyle}
+              >{`댓글 +${comments?.length - displayedCommentCount}`}</span>
               <span className={moreCommentButtonStyle}>더보기</span>
             </div>
           </Link>

--- a/apps/client/src/app/[user]/components/FeedItem/index.tsx
+++ b/apps/client/src/app/[user]/components/FeedItem/index.tsx
@@ -21,7 +21,6 @@ import {
   studyNameStyle,
 } from "@/app/[user]/components/FeedItem/index.css";
 import { useCommentListQueryObject } from "@/app/api/comments/query";
-import type { CommentContent } from "@/app/api/comments/type";
 import { useGroupInfoQueryObject } from "@/app/api/groups/query";
 import { useSolutionQueryObject } from "@/app/api/solutions/query";
 import { formatDistanceDate } from "@/common/util/date";
@@ -51,7 +50,6 @@ const FeedItem = ({ solutionId, groupId }: FeedItemProps) => {
         {
           ...useCommentListQueryObject(solutionId),
           retry: 0,
-          select: (data: CommentContent[]) => [...data].reverse(),
         },
         {
           ...useGroupInfoQueryObject(groupId),
@@ -156,8 +154,6 @@ const FeedItem = ({ solutionId, groupId }: FeedItemProps) => {
         <CommentInput
           onCommentCountPlus={handleCommentCountPlus}
           solutionId={solutionId}
-          profileUrl={solution?.profileImage}
-          nickname={solution?.nickname}
         />
       </article>
     </li>

--- a/apps/client/src/app/[user]/components/FeedItem/index.tsx
+++ b/apps/client/src/app/[user]/components/FeedItem/index.tsx
@@ -39,7 +39,7 @@ const DEFAULT_COMMENT_COUNT = 3;
 const FeedItem = ({ solutionId, groupId }: FeedItemProps) => {
   const myAddedCommentsRef = useRef(0);
   const displayedCommentCount =
-    myAddedCommentsRef.current + DEFAULT_COMMENT_COUNT;
+    DEFAULT_COMMENT_COUNT + myAddedCommentsRef.current;
 
   const [{ data: solution }, { data: comments }, { data: group }] =
     useSuspenseQueries({
@@ -58,6 +58,10 @@ const FeedItem = ({ solutionId, groupId }: FeedItemProps) => {
         },
       ],
     });
+
+  const displayedComments = comments
+    ?.toReversed()
+    .slice(comments.length - displayedCommentCount, comments.length);
 
   // 피드에 뜨게한 댓글 찾기 - 나를 제외한 최신 댓글
   const triggerComment = useMemo(
@@ -121,7 +125,7 @@ const FeedItem = ({ solutionId, groupId }: FeedItemProps) => {
         />
 
         <ul className={commentListStyle}>
-          {comments?.slice(0, displayedCommentCount).map((comment) => (
+          {displayedComments.map((comment) => (
             <li
               key={comment.commentId}
               className={commentItemStyle}

--- a/apps/client/src/app/[user]/page.tsx
+++ b/apps/client/src/app/[user]/page.tsx
@@ -17,9 +17,8 @@ import Sidebar from "@/common/component/Sidebar";
 import { prefetchQuery } from "@/shared/util/prefetch";
 import { sidebarWrapper } from "@/styles/shared.css";
 
-import { HydrationBoundary } from "@tanstack/react-query";
-
 import MyFeedSection from "@/app/[user]/components/MyFeedSection";
+import { HydrationBoundary } from "@tanstack/react-query";
 import { HTTPError } from "ky";
 import { notFound } from "next/navigation";
 import { useRecommendStudyQueryObject } from "../api/users/query";
@@ -77,8 +76,8 @@ const UserDashboardPage = async ({ params }: { params: { user: string } }) => {
       <div className={userHomeWrapper}>
         <HydrationBoundary state={recommendGroups}>
           <RecommendStudySection />
-          <MyFeedSection />
         </HydrationBoundary>
+        <MyFeedSection />
       </div>
       <Sidebar>{/* <div>임시로 만드는 우측 패널</div> */}</Sidebar>
     </main>

--- a/apps/client/src/app/[user]/page.tsx
+++ b/apps/client/src/app/[user]/page.tsx
@@ -25,8 +25,6 @@ import { useRecommendStudyQueryObject } from "../api/users/query";
 import UserPageLeftSidebar from "./components/LeftSidebar";
 import RecommendStudySection from "./components/RecommendSection";
 
-export const revalidate = 60;
-
 const UserDashboardPage = async ({ params }: { params: { user: string } }) => {
   const userInfo = await auth();
   const { user } = params;

--- a/apps/client/src/app/api/comments/mutation.ts
+++ b/apps/client/src/app/api/comments/mutation.ts
@@ -17,7 +17,7 @@ export const useCommentMutation = (solutionId: number) => {
     mutationFn: (content: string) => postCommentInput(solutionId, content),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: commentQueryKey.all(),
+        queryKey: commentQueryKey.list(solutionId),
       });
     },
     onError: () => {

--- a/apps/client/src/app/api/comments/query.ts
+++ b/apps/client/src/app/api/comments/query.ts
@@ -1,3 +1,4 @@
+import type { CommentContent } from "@/app/api/comments/type";
 import { queryOptions } from "@tanstack/react-query";
 import { getCommentList } from "./index";
 
@@ -12,4 +13,5 @@ export const useCommentListQueryObject = (solutionId: number) =>
   queryOptions({
     queryKey: commentQueryKey.list(solutionId),
     queryFn: () => getCommentList(solutionId),
+    select: (data: CommentContent[]) => [...data].reverse(),
   });

--- a/apps/client/src/app/api/comments/query.ts
+++ b/apps/client/src/app/api/comments/query.ts
@@ -13,5 +13,5 @@ export const useCommentListQueryObject = (solutionId: number) =>
   queryOptions({
     queryKey: commentQueryKey.list(solutionId),
     queryFn: () => getCommentList(solutionId),
-    select: (data: CommentContent[]) => [...data].reverse(),
+    select: (data: CommentContent[]) => data.toReversed(),
   });


### PR DESCRIPTION
## ✅ Done Task
  - [x] 댓글 입력 컴포넌트 간격 조정
  - [x] 댓글 입력 사용자 사진 본인으로 변경
  - [x] 댓글 최신 3개 보이게
 

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
매우 엉망으로 구현을 해서 고칠부분이 많았네요..
빠르게 다 고쳐서 정상적인 뷰로 구현해두겠습니다!

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

### 댓글 입력 컴포넌트 스타일 조정

<img width="1099" height="107" alt="스크린샷 2026-01-29 오후 4 33 06" src="https://github.com/user-attachments/assets/00fae4f6-bcf7-4a8a-bed7-8d0431466aa0" />

간격이 안맞고, 풀이를 올린 사람의 프로필이 댓글 입력 창에 뜨고있어 useSession 훅 활용해 수정해주었습니다.
근데 내 정보를 이렇게 가져오는게 맞는지? 다른 방법이 있으면 알려주시면 감사할거 같아요.

<img width="1078" height="105" alt="스크린샷 2026-01-29 오후 4 34 07" src="https://github.com/user-attachments/assets/83adbb5b-eee4-4735-b65f-e122de016fc6" />

### 댓글 최신 3개 보이게
```tsx
const displayedComments = comments?.slice(
    comments.length - displayedCommentCount,
    comments.length,
  );
```
댓글이 최신 3개가 아닌, 첫댓글 부터 3개가 보이게 로직이 구현되어있어 이를 최신 3개로 수정해주었습니다. 
수정하고 보니 댓글 더보기의 위치가 밑이 아니라 위에 있어야 더 자연스러울거 같단 생각도 들어 디자이너분과 상의해볼게요. 

근데 이상하게 댓글 더보기 모달을 들어갔다 나오면 댓글의 순서가 바뀌는 버그가 있었습니다.
원인을 추적해보니 모달 내에서 comments.sort() 로직이 있어 쿼리 캐시 자체를 바꾸어 버리고 있었습니다.
(주용아... 덕분아 1시간 날렸다..)
```tsx
comments
  ?.sort((a, b) => +new Date(a.createdAt) - +new Date(b.createdAt))
  .map((item) => (
    />
  ));
```

이를 예방하고 관심사를 명확하게 하기 위해 queryObject에서 select 옵션에서 `toReverse` 메서드 사용해 원본배열 안건드리게 헤주었어요.
댓글을 두 뷰 모두 과거순으로 보여주고, 댓글을 최신순으로 보여줄 뷰는 없을거라 판단해 queryObject 자체에 넣어주었습니다.
```tsx
export const useCommentListQueryObject = (solutionId: number) =>
  queryOptions({
    queryKey: commentQueryKey.list(solutionId),
    queryFn: () => getCommentList(solutionId),
    select: (data: CommentContent[]) => data.toReversed(),
  });
```

- [user] 페이지에 `revalidation`이 걸려있어서 확인해보니 어차피 dynamic 페이지라 의미가 없는 코드라 생각해 삭제해주었어요.
혹시 꼭 필요한 코드면 알려주세요!

- 피드 순서와 뜨는 기준도 손봐야 하는데 이건 서버분과 의논해서 추후 다른 pr에 올릴게요.

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

